### PR TITLE
Fix queue issues [Linux/Mesa] 6_deferred_async_load error: "transfer_queue := gpu.get_queue(.Transfer)" results in "[gpu_vulkan.odin:2595:vk_submit_cmd_buf()] Vulkan failure: ERROR_DEVICE_LOST"

### DIFF
--- a/gpu/gpu_vulkan.odin
+++ b/gpu/gpu_vulkan.odin
@@ -353,8 +353,6 @@ _init :: proc()
         }
     }
 
-    log.debug("queue_create_infos:", queue_create_infos) 
-
     // Device
     device_extensions := []cstring {
         vk.KHR_SWAPCHAIN_EXTENSION_NAME,
@@ -425,8 +423,6 @@ _init :: proc()
     for &queue in ctx.queues[1:] {
         vk.GetDeviceQueue(ctx.device, queue.family_idx, queue.queue_idx, &queue.handle)
     }
-
-    log.debug("queues:", ctx.queues)
 
     // Common resources
     {


### PR DESCRIPTION
Fixes #30
- We now always request only one queue per family
- We are also checking that the queue family has at least one queue before considering it
- Getting vk.Queue for gpu.Queue now happens inside init instead of every time we are traslating Queue_Family
- Also I've removed locking around Queue_Family -> Queue lookup because after init this is threadsafe