### PR TITLE
Add entrypoint name to shader_create

### DIFF
--- a/gpu/gpu.odin
+++ b/gpu/gpu.odin
@@ -168,8 +168,8 @@ get_texture_rw_view_descriptor_size: proc() -> u32 : _get_texture_rw_view_descri
 get_sampler_descriptor_size: proc() -> u32 : _get_sampler_descriptor_size
 
 // Shaders
-shader_create: proc(code: []u32, type: Shader_Type_Graphics, entry_point_name: cstring = "main") -> Shader : _shader_create
-shader_create_compute: proc(code: []u32, group_size_x: u32, group_size_y: u32 = 1, group_size_z: u32 = 1, entry_point_name: cstring = "main") -> Shader : _shader_create_compute
+shader_create: proc(code: []u32, type: Shader_Type_Graphics, entry_point_name: string = "main") -> Shader : _shader_create
+shader_create_compute: proc(code: []u32, group_size_x: u32, group_size_y: u32 = 1, group_size_z: u32 = 1, entry_point_name: string = "main") -> Shader : _shader_create_compute
 shader_destroy: proc(shader: Shader) : _shader_destroy
 
 // Semaphores


### PR DESCRIPTION
I've been building a renderer based on no_gfx_api and settled on slang for shaders. I really like having a single shader file with multiple entrypoints, however getting slang to output 2 spirv bundles with each entrypoint renamed as "main" is non trivial and also suboptimal because you need to compile the same shader twice.

This is the first time we are using string arguments. Is cstring the best way to do this, or something else? We will be adding debug names to object creation at some point and those will be strings as well.