### PR TITLE
Add tests

### DIFF
--- a/examples/1_triangle/main.odin
+++ b/examples/1_triangle/main.odin
@@ -1,5 +1,5 @@
 
-package main
+package example1
 
 import log "core:log"
 import "core:math"
@@ -14,10 +14,14 @@ Start_Window_Size_Y :: 1000
 Frames_In_Flight :: 3
 Example_Name :: "Triangle"
 
+Total_Max_Frames := max(u64)
+
 main :: proc()
 {
     ok_i := sdl.Init({ .VIDEO })
     assert(ok_i)
+    // Ensure SDL shuts down cleanly between test runs.
+    defer sdl.Quit()
 
     console_logger := log.create_console_logger()
     defer log.destroy_console_logger(console_logger)
@@ -90,7 +94,7 @@ main :: proc()
     next_frame := u64(1)
     frame_sem := gpu.semaphore_create(0)
     defer gpu.semaphore_destroy(&frame_sem)
-    for true
+    for next_frame < Total_Max_Frames
     {
         proceed := handle_window_events(window)
         if !proceed do break

--- a/examples/2_textures/main.odin
+++ b/examples/2_textures/main.odin
@@ -1,5 +1,5 @@
 
-package main
+package example2
 
 import log "core:log"
 import "core:image"
@@ -19,10 +19,13 @@ Example_Name :: "Textures"
 Peach_Texture :: #load("textures/peach.png")
 Bowser_Texture :: #load("textures/bowser.png")
 
+Total_Max_Frames := max(u64)
+
 main :: proc()
 {
     ok_i := sdl.Init({ .VIDEO })
     assert(ok_i)
+    defer sdl.Quit()
 
     console_logger := log.create_console_logger()
     defer log.destroy_console_logger(console_logger)
@@ -120,7 +123,7 @@ main :: proc()
     next_frame := u64(1)
     frame_sem := gpu.semaphore_create(0)
     defer gpu.semaphore_destroy(&frame_sem)
-    for true
+    for next_frame < Total_Max_Frames
     {
         proceed := handle_window_events(window)
         if !proceed do break

--- a/examples/3_3D/main.odin
+++ b/examples/3_3D/main.odin
@@ -1,5 +1,5 @@
 
-package main
+package example3
 
 import log "core:log"
 import "../../gpu"
@@ -20,16 +20,20 @@ Example_Name :: "3D"
 
 Sponza_Scene :: #load("../shared/assets/sponza.glb")
 
+Total_Max_Frames := max(u64)
+
 main :: proc()
 {
-    fmt.println("Right-click + WASD for first-person controls.")
-
     ok_i := sdl.Init({ .VIDEO })
     assert(ok_i)
+    defer sdl.Quit()
 
     console_logger := log.create_console_logger()
     defer log.destroy_console_logger(console_logger)
     context.logger = console_logger
+
+    log.info("Right-click + WASD for first-person controls.")
+
 
     ts_freq := sdl.GetPerformanceFrequency()
     max_delta_time: f32 = 1.0 / 10.0  // 10fps
@@ -75,7 +79,7 @@ main :: proc()
 
     upload_cmd_buf := gpu.commands_begin(queue)
 
-	scene, _, gltf_data := shared.load_scene_gltf(
+	scene, texture_infos, gltf_data := shared.load_scene_gltf(
 		Sponza_Scene,
 		&upload_arena,
 		upload_cmd_buf,
@@ -83,6 +87,7 @@ main :: proc()
 	defer {
 		shared.destroy_scene(&scene)
 		gltf2.unload(gltf_data)
+        delete(texture_infos)
 	}
 
     gpu.cmd_barrier(upload_cmd_buf, .Transfer, .All, {})
@@ -96,7 +101,7 @@ main :: proc()
     next_frame := u64(1)
     frame_sem := gpu.semaphore_create(0)
     defer gpu.semaphore_destroy(&frame_sem)
-    for true
+    for next_frame < Total_Max_Frames
     {
         proceed := shared.handle_window_events(window)
         if !proceed do break

--- a/examples/4_indirect_triangles/main.odin
+++ b/examples/4_indirect_triangles/main.odin
@@ -1,5 +1,5 @@
 
-package main
+package example4
 
 import log "core:log"
 import "core:math"
@@ -15,12 +15,15 @@ Frames_In_Flight :: 3
 Example_Name :: "Indirect Multi Triangles"
 Num_Triangles :: 32
 
-Use_Indirect_Multi :: true
+Use_Indirect_Multi := true
+
+Total_Max_Frames := max(u64)
 
 main :: proc()
 {
     ok_i := sdl.Init({ .VIDEO })
     assert(ok_i)
+    defer sdl.Quit()
 
     console_logger := log.create_console_logger()
     defer log.destroy_console_logger(console_logger)
@@ -146,7 +149,7 @@ main :: proc()
     next_frame := u64(1)
     frame_sem := gpu.semaphore_create(0)
     defer gpu.semaphore_destroy(&frame_sem)
-    for true
+    for next_frame < Total_Max_Frames
     {
         proceed := handle_window_events(window)
         if !proceed do break
@@ -188,7 +191,7 @@ main :: proc()
         shared_vert_data := gpu.arena_alloc(frame_arena, Vert_Data)
         shared_vert_data.cpu.verts = verts_local
 
-        when Use_Indirect_Multi {
+        if Use_Indirect_Multi {
             // Draw multiple indexed triangles using indirect rendering
             // Arguments:
             //   cmd_buf: Command buffer to record the draw command

--- a/examples/5_compute_shaders/main.odin
+++ b/examples/5_compute_shaders/main.odin
@@ -1,5 +1,5 @@
 
-package main
+package example5
 
 import log "core:log"
 import "core:math"
@@ -16,18 +16,21 @@ Frames_In_Flight :: 3
 Example_Name :: "Compute Shader"
 
 // Whether to use indirect dispatch (group counts) or direct dispatch (thread counts)
-Use_Indirect :: true
+Use_Indirect := true
+
+Total_Max_Frames := max(u64)
 
 main :: proc()
 {
-    fmt.println("CREDITS: Shader \"Clearly a bug\" by Glow on https://www.shadertoy.com/view/33cGDj")
-
     ok_i := sdl.Init({ .VIDEO })
     assert(ok_i)
-
+    defer sdl.Quit()
+    
     console_logger := log.create_console_logger()
     defer log.destroy_console_logger(console_logger)
     context.logger = console_logger
+
+    log.info("CREDITS: Shader \"Clearly a bug\" by Glow on https://www.shadertoy.com/view/33cGDj")
 
     ts_freq := sdl.GetPerformanceFrequency()
     max_delta_time: f32 = 1.0 / 10.0  // 10fps
@@ -159,7 +162,7 @@ main :: proc()
     next_frame := u64(1)
     frame_sem := gpu.semaphore_create(0)
     defer gpu.semaphore_destroy(&frame_sem)
-    for true
+    for next_frame < Total_Max_Frames
     {
         proceed := handle_window_events(window)
         if !proceed do break

--- a/examples/6_deferred_async_load/main.odin
+++ b/examples/6_deferred_async_load/main.odin
@@ -5,7 +5,7 @@
 // - Asynchronous texture loading by rendering a default texture and swapping it out for the actual textures once loaded
 // - Multithreaded texture loading
 
-package main
+package example6
 
 import "../../gpu"
 import intr "base:intrinsics"
@@ -37,11 +37,13 @@ Example_Name_Format :: "Right-click + WASD for first-person controls. Left click
 Sponza_Scene :: #load("../shared/assets/sponza.glb")
 
 // Whether to load textures in parallel in the background or preload them in main thread before running the screne
-Load_Textures_Async :: true
+Load_Textures_Async := true
 Num_Async_Worker_Threads := clamp(info.cpu.logical_cores - 1, 2, 6)
 
 // How many textures to load in a single batch / command buffer
 Loader_Chunk_Size :: 16
+
+Total_Max_Frames := max(u64)
 
 // G-buffer texture indices in texture heap
 GBUFFER_ALBEDO_IDX :: 1000
@@ -56,25 +58,27 @@ GBuffer_Texture_Type :: enum u32 {
 }
 
 // Currently selected gbuffer texture type to display
-selected_texture_type: GBuffer_Texture_Type = .Albedo
+Selected_Texture_Type: GBuffer_Texture_Type = .Albedo
 
-// Textures can be loaded/unloaded on different threads, so we need to synchronize access to loaded_textures, image_to_texture and image_uploaded
-mutex: sync.Mutex
-// Every texture from loaded_textures array needs to be freed when we are done
-loaded_textures: [dynamic]gpu.Owned_Texture
+// Textures can be loaded/unloaded on different threads, so we need to synchronize access to
+// Loaded_Textures, Image_To_Texture, and Image_Uploaded.
+Texture_Load_Mutex: sync.Mutex
+// Every texture from Loaded_Textures array needs to be freed when we are done
+Loaded_Textures: [dynamic]gpu.Owned_Texture
 // Enables asynchronous cancellation of texture loading
-cancel_loading_textures: bool
-next_texture_idx: u32 = shared.MISSING_TEXTURE_ID + 1
+Cancel_Loading_Textures: bool
+Next_Texture_Idx: u32 = shared.MISSING_TEXTURE_ID + 1
 // Cache for image_index -> texture mapping, reused across texture loading chunks
-image_to_texture: map[int]struct {
+Image_To_Texture: map[int]struct {
 	texture:     gpu.Owned_Texture,
 	texture_idx: u32,
 }
-image_uploaded: map[int]^sync.One_Shot_Event
+Image_Uploaded: map[int]^sync.One_Shot_Event
 
 main :: proc() {
 	ok_i := sdl.Init({.VIDEO})
 	assert(ok_i)
+	defer sdl.Quit()
 
 	console_logger := log.create_console_logger()
 	defer log.destroy_console_logger(console_logger)
@@ -85,7 +89,7 @@ main :: proc() {
 
 	window_flags :: sdl.WindowFlags{.HIGH_PIXEL_DENSITY, .VULKAN, .RESIZABLE}
 	window_title := strings.clone_to_cstring(
-		fmt.tprintf(Example_Name_Format, selected_texture_type),
+		fmt.tprintf(Example_Name_Format, Selected_Texture_Type),
 	)
 	defer delete(window_title)
 	window := sdl.CreateWindow(
@@ -160,24 +164,33 @@ main :: proc() {
 		shared.destroy_scene(&scene)
 		gltf2.unload(gltf_data)
 	}
+	defer delete(texture_infos)
 
     defer {
         // Clean up loaded textures
-        sync.guard(&mutex)
-        for &tex in loaded_textures {
+        sync.guard(&Texture_Load_Mutex)
+        for &tex in Loaded_Textures {
             gpu.free_and_destroy_texture(&tex)
         }
     }
 
-	when Load_Textures_Async {
-		worker_threads: [dynamic]^thread.Thread
-		defer {
-			cancel_loading_textures = true
-			for t in worker_threads {
-				thread.terminate(t, 0)
-			}
-		}
+    defer {
+        for i, event in Image_Uploaded {
+            free(event)
+        }
+    }
 
+    worker_threads: [dynamic]^thread.Thread
+    defer {
+        Cancel_Loading_Textures = true
+        for t in worker_threads {
+            thread.terminate(t, 0)
+            thread.join(t)
+            thread.destroy(t)
+        }
+        delete(worker_threads)
+    }
+	if Load_Textures_Async {
 		Texture_Loader_Data :: struct {
 			texture_infos: []shared.Gltf_Texture_Info,
 			gltf_data:     ^gltf2.Data,
@@ -195,11 +208,15 @@ main :: proc() {
             current_chunk = new(int),
         }
 
+        defer {
+            free(loader_data.current_chunk)
+        }
+
         texture_loader_thread_proc :: proc(thread: ^thread.Thread) {
             data := cast(^Texture_Loader_Data)thread.data
             context.logger = data.logger
 
-            for !cancel_loading_textures {
+            for !Cancel_Loading_Textures {
                 current_chunk_start := sync.atomic_add(data.current_chunk, Loader_Chunk_Size)
                 current_chunk_end := min(current_chunk_start + Loader_Chunk_Size, len(data.texture_infos))
 
@@ -262,15 +279,15 @@ main :: proc() {
 	next_frame := u64(1)
 	frame_sem := gpu.semaphore_create(0)
 	defer gpu.semaphore_destroy(&frame_sem)
-	for true {
+	for next_frame < Total_Max_Frames {
 		proceed := shared.handle_window_events(window)
 		if !proceed do break
 
 		// Toggle gbuffer texture type on left mouse button click
 		if shared.INPUT.left_click_pressed {
-			selected_texture_type = GBuffer_Texture_Type((u32(selected_texture_type) + 1) % 3)
+			Selected_Texture_Type = GBuffer_Texture_Type((u32(Selected_Texture_Type) + 1) % 3)
 			title := strings.clone_to_cstring(
-				fmt.tprintf(Example_Name_Format, selected_texture_type),
+				fmt.tprintf(Example_Name_Format, Selected_Texture_Type),
 			)
 			sdl.SetWindowTitle(window, title)
 			delete(title)
@@ -524,7 +541,7 @@ render_pass_final :: proc(
 		gbuffer_normal_sampler             = 0,
 		gbuffer_metallic_roughness         = GBUFFER_METALLIC_ROUGHNESS_IDX,
 		gbuffer_metallic_roughness_sampler = 0,
-		selected_texture_type              = i32(selected_texture_type),
+		selected_texture_type              = i32(Selected_Texture_Type),
 	}
 
 	// Render fullscreen quad
@@ -714,7 +731,7 @@ load_scene_textures_from_gltf :: proc(
 	defer gpu.arena_destroy(&upload_arena)
 
 	for info in texture_infos {
-		if cancel_loading_textures {
+		if Cancel_Loading_Textures {
 			return
 		}
 
@@ -729,16 +746,16 @@ load_scene_textures_from_gltf :: proc(
 			continue
 		}
 
-		sync.mutex_lock(&mutex)
-		if event, ok := image_uploaded[info.image_index]; ok {
-			sync.mutex_unlock(&mutex)
+		sync.mutex_lock(&Texture_Load_Mutex)
+		if event, ok := Image_Uploaded[info.image_index]; ok {
+			sync.mutex_unlock(&Texture_Load_Mutex)
 			sync.one_shot_event_wait(event)
 		} else {
-			texture_idx := next_texture_idx
-			next_texture_idx += 1
+			texture_idx := Next_Texture_Idx
+			Next_Texture_Idx += 1
 			event := new(sync.One_Shot_Event)
-			image_uploaded[info.image_index] = event
-			sync.mutex_unlock(&mutex)
+			Image_Uploaded[info.image_index] = event
+			sync.mutex_unlock(&Texture_Load_Mutex)
 
 			upload_cmd_buf := gpu.commands_begin(transfer_queue)
 
@@ -753,7 +770,7 @@ load_scene_textures_from_gltf :: proc(
 			gpu.cmd_barrier(upload_cmd_buf, .Transfer, .All, {})
 			gpu.queue_submit(transfer_queue, {upload_cmd_buf})
 
-			if sync.guard(&mutex) do image_to_texture[info.image_index] = {texture, texture_idx}
+			if sync.guard(&Texture_Load_Mutex) do Image_To_Texture[info.image_index] = {texture, texture_idx}
 
 			sync.one_shot_event_signal(event)
 
@@ -771,8 +788,8 @@ load_scene_textures_from_gltf :: proc(
 	gpu.queue_wait_idle(transfer_queue)
 
 	for info in texture_infos {
-		sync.guard(&mutex)
-		texture := image_to_texture[info.image_index]
+		sync.guard(&Texture_Load_Mutex)
+		texture := Image_To_Texture[info.image_index]
 
 		switch info.texture_type {
 		case .Base_Color:
@@ -871,7 +888,7 @@ load_texture_from_gltf :: proc(
 		},
 		queue,
 	)
-	if sync.guard(&mutex) do append(&loaded_textures, texture)
+	if sync.guard(&Texture_Load_Mutex) do append(&Loaded_Textures, texture)
 
 	gpu.cmd_copy_to_texture(cmd_buf, texture, staging_gpu, texture.mem)
 	return texture

--- a/gpu/gpu.odin
+++ b/gpu/gpu.odin
@@ -2,6 +2,7 @@
 package gpu
 
 import "core:slice"
+import "core:log"
 import "base:runtime"
 
 import sdl "vendor:sdl3"
@@ -47,6 +48,9 @@ Address_Mode :: enum { Repeat = 0, Mirrored_Repeat, Clamp_To_Edge }
 // Constants
 All_Mips: u8 : max(u8)
 All_Layers: u16 : max(u16)
+
+// Optional hook for capturing GPU debug messages (e.g. validation errors).
+Hook_Debug_Log: proc(level: log.Level, message: cstring)
 
 // Structs
 Texture_Desc :: struct

--- a/gpu/gpu_vulkan.odin
+++ b/gpu/gpu_vulkan.odin
@@ -152,6 +152,14 @@ Queue_Info :: struct
 @(private="file")
 ctx: Context
 
+@(private="file")
+// Allow multiple init/cleanup pairs in tests.
+init_ref_count: i32
+
+@(private="file")
+// Vulkan global proc addresses only need loading once per process.
+vk_globals_loaded: bool
+
 @(private="file") @(thread_local)
 tls_ctx: ^Thread_Local_Context
 
@@ -160,12 +168,21 @@ vk_logger: log.Logger
 
 _init :: proc()
 {
+    if init_ref_count > 0 {
+        init_ref_count += 1
+        return
+    }
+    init_ref_count = 1
+
     init_scratch_arenas()
 
     scratch, _ := acquire_scratch()
 
     // Load vulkan function pointers
-    vk.load_proc_addresses_global(cast(rawptr) get_instance_proc_address)
+    if !vk_globals_loaded {
+        vk.load_proc_addresses_global(cast(rawptr) get_instance_proc_address)
+        vk_globals_loaded = true
+    }
 
     vk_logger = context.logger
 
@@ -203,6 +220,7 @@ _init :: proc()
             messageType = { .VALIDATION, .PERFORMANCE },
             pfnUserCallback = vk_debug_callback
         }
+
 
         when ODIN_DEBUG
         {
@@ -666,6 +684,14 @@ tls_init :: proc()
 
 _cleanup :: proc()
 {
+    if init_ref_count <= 0 {
+        return
+    }
+    init_ref_count -= 1
+    if init_ref_count > 0 {
+        return
+    }
+
     sync.guard(&ctx.lock)
 
     // Cleanup all TLS contexts
@@ -684,12 +710,22 @@ _cleanup :: proc()
     }
     delete(ctx.tls_contexts)
     ctx.tls_contexts = {}
+    // Ensure TLS contexts are rebuilt after cleanup.
+    tls_ctx = nil
 
     for &sampler in ctx.samplers {
         vk.DestroySampler(ctx.device, sampler.sampler, nil)
     }
+    delete(ctx.samplers)
+    ctx.samplers = {}
+
+    delete(ctx.current_workgroup_size)
+    ctx.current_workgroup_size = {}
+    delete(ctx.cmd_buf_compute_shader)
+    ctx.cmd_buf_compute_shader = {}
 
     destroy_swapchain(&ctx.swapchain)
+    pool_destroy(&ctx.textures)
 
     vk.DestroyDescriptorSetLayout(ctx.device, ctx.textures_desc_layout, nil)
     vk.DestroyDescriptorSetLayout(ctx.device, ctx.textures_rw_desc_layout, nil)
@@ -698,6 +734,20 @@ _cleanup :: proc()
     vk.DestroyDescriptorSetLayout(ctx.device, ctx.indirect_data_desc_layout, nil)
     vk.DestroyPipelineLayout(ctx.device, ctx.common_pipeline_layout_graphics, nil)
     vk.DestroyPipelineLayout(ctx.device, ctx.common_pipeline_layout_compute, nil)
+
+    // Ensure any outstanding allocations are released before tearing down VMA.
+    for &meta in ctx.gpu_allocs {
+        if meta.buf_handle != {} {
+            vma.destroy_buffer(ctx.vma_allocator, meta.buf_handle, meta.allocation)
+        }
+    }
+    delete(ctx.gpu_allocs)
+    ctx.gpu_allocs = {}
+    delete(ctx.cpu_ptr_to_alloc)
+    ctx.cpu_ptr_to_alloc = {}
+    delete(ctx.gpu_ptr_to_alloc)
+    ctx.gpu_ptr_to_alloc = {}
+    ctx.alloc_tree = {}
 
     vma.destroy_allocator(ctx.vma_allocator)
 
@@ -1028,16 +1078,18 @@ _mem_free :: proc(ptr: rawptr, loc := #caller_location)
 
     if cpu_found
     {
-        meta := ctx.gpu_allocs[cpu_alloc]
+        meta := &ctx.gpu_allocs[cpu_alloc]
         rbt.remove_key(&ctx.alloc_tree, Alloc_Range { u64(meta.device_address), u32(meta.buf_size) })
         vma.destroy_buffer(ctx.vma_allocator, meta.buf_handle, meta.allocation)
+        meta^ = {}
         delete_key(&ctx.cpu_ptr_to_alloc, ptr)
     }
     else if gpu_found
     {
-        meta := ctx.gpu_allocs[gpu_alloc]
+        meta := &ctx.gpu_allocs[gpu_alloc]
         rbt.remove_key(&ctx.alloc_tree, Alloc_Range { u64(meta.device_address), u32(meta.buf_size) })
         vma.destroy_buffer(ctx.vma_allocator, meta.buf_handle, meta.allocation)
+        meta^ = {}
         delete_key(&ctx.gpu_ptr_to_alloc, ptr)
     }
 }
@@ -2118,6 +2170,9 @@ vk_debug_callback :: proc "system" (severity: vk.DebugUtilsMessageSeverityFlagsE
     else if .INFO in severity    do level = .Info
     else                         do level = .Debug
     log.log(level, callback_data.pMessage)
+    if Hook_Debug_Log != nil {
+        Hook_Debug_Log(level, callback_data.pMessage)
+    }
 
     return false
 }
@@ -2146,8 +2201,17 @@ align_up :: proc(x, align: u64) -> (aligned: u64)
 scratch_arenas: [4]vmem.Arena
 
 @(private="file")
+// Avoid reinitializing scratch arenas between tests.
+scratch_arenas_initialized: bool
+
+@(private="file")
 init_scratch_arenas :: proc()
 {
+    if scratch_arenas_initialized {
+        return
+    }
+    scratch_arenas_initialized = true
+
     for &scratch in scratch_arenas
     {
         error := vmem.arena_init_growing(&scratch)
@@ -2296,6 +2360,13 @@ create_swapchain :: proc(width: u32, height: u32, frames_in_flight: u32) -> Swap
 destroy_swapchain :: proc(swapchain: ^Swapchain)
 {
     delete(swapchain.images)
+    for key in swapchain.texture_keys {
+        tex_info := get_resource(key, ctx.textures)
+        delete(tex_info.views)
+        tex_info.views = {}
+        pool_free_idx(&ctx.textures, u32(key.idx))
+    }
+    delete(swapchain.texture_keys)
     for semaphore in swapchain.present_semaphores {
         vk.DestroySemaphore(ctx.device, semaphore, nil)
     }

--- a/gpu/vma/vma.odin
+++ b/gpu/vma/vma.odin
@@ -6,10 +6,10 @@ when ODIN_OS == .Linux || ODIN_OS == .Darwin {
 
 when ODIN_OS == .Windows {
 	when ODIN_ARCH == .amd64 {
-		@(extra_linker_flags="/NODEFAULTLIB:libcmt /NODEFAULTLIB:libucrt")
+		@(extra_linker_flags="/NODEFAULTLIB:libcmt /NODEFAULTLIB:libucrt /DEFAULTLIB:ucrt")
 		foreign import _lib_ "vma_windows_x86_64.lib"
 	} else when ODIN_ARCH == .arm64 {
-		@(extra_linker_flags="/NODEFAULTLIB:libcmt /NODEFAULTLIB:libucrt")
+		@(extra_linker_flags="/NODEFAULTLIB:libcmt /NODEFAULTLIB:libucrt /DEFAULTLIB:ucrt")
 		foreign import _lib_ "vma_windows_ARM64.lib"
 	} else {
 		#panic("Unsupported architecture for VMA library on Windows")

--- a/tests/example_tests.odin
+++ b/tests/example_tests.odin
@@ -1,0 +1,166 @@
+package tests
+
+import gpu "../gpu"
+import example1 "../examples/1_triangle"
+import example2 "../examples/2_textures"
+import example3 "../examples/3_3D"
+import example4 "../examples/4_indirect_triangles"
+import example5 "../examples/5_compute_shaders"
+import example6 "../examples/6_deferred_async_load"
+import shared "../examples/shared"
+import log "core:log"
+import "core:sync"
+import testing "core:testing"
+import "base:runtime"
+
+// Collect validation errors from the GPU debug hook.
+validation_errors: [dynamic]string
+
+// Only one instance of no_gfx_api can be running at a time.
+test_mutex: sync.Mutex
+
+validation_error_logger :: proc(level: log.Level, message: cstring) {
+    if level != .Error {
+        return
+    }
+
+    append(&validation_errors, runtime.cstring_to_string(message))
+}
+
+setup_validation_error_hook :: proc() {
+    clear(&validation_errors)
+    ctx := runtime.default_context()
+    validation_errors = make([dynamic]string, allocator = ctx.allocator)
+    gpu.Hook_Debug_Log = validation_error_logger
+}
+
+assert_no_validation_errors :: proc(t: ^testing.T) {
+    gpu.Hook_Debug_Log = nil
+    if len(validation_errors) == 0 {
+        return
+    }
+
+    for err in validation_errors {
+        log.errorf("Validation error: %s", err)
+    }
+    testing.fail(t)
+}
+
+@(test)
+example1_validation :: proc(t: ^testing.T) {
+    sync.guard(&test_mutex)
+    setup_validation_error_hook()
+    example1.Total_Max_Frames = 10
+    example1.main()
+    assert_no_validation_errors(t)
+}
+
+@(test)
+example2_validation :: proc(t: ^testing.T) {
+    sync.guard(&test_mutex)
+    setup_validation_error_hook()
+    example2.Total_Max_Frames = 10
+    example2.main()
+    assert_no_validation_errors(t)
+    gpu.cleanup()
+}
+
+@(test)
+example3_validation :: proc(t: ^testing.T) {
+    sync.guard(&test_mutex)
+    setup_validation_error_hook()
+    example3.Total_Max_Frames = 10
+    example3.main()
+    assert_no_validation_errors(t)
+    gpu.cleanup()
+}
+
+@(test)
+example4_validation_indirect_multi :: proc(t: ^testing.T) {
+    sync.guard(&test_mutex)
+    setup_validation_error_hook()
+    example4.Use_Indirect_Multi = true
+    example4.Total_Max_Frames = 10
+    example4.main()
+    assert_no_validation_errors(t)
+    gpu.cleanup()
+}
+
+@(test)
+example4_validation_single_indirect :: proc(t: ^testing.T) {
+    sync.guard(&test_mutex)
+    setup_validation_error_hook()
+    example4.Use_Indirect_Multi = false
+    example4.Total_Max_Frames = 10
+    example4.main()
+    assert_no_validation_errors(t)
+    gpu.cleanup()
+}
+
+@(test)
+example5_validation_indirect :: proc(t: ^testing.T) {
+    sync.guard(&test_mutex)
+    setup_validation_error_hook()
+    example5.Use_Indirect = true
+    example5.Total_Max_Frames = 10
+    example5.main()
+    assert_no_validation_errors(t)
+    gpu.cleanup()
+}
+
+@(test)
+example5_validation_direct :: proc(t: ^testing.T) {
+    sync.guard(&test_mutex)
+    setup_validation_error_hook()
+    example5.Use_Indirect = false
+    example5.Total_Max_Frames = 10
+    example5.main()
+    assert_no_validation_errors(t)
+    gpu.cleanup()
+}
+
+reset_example6_static_state :: proc() {
+	example6.Selected_Texture_Type = .Albedo
+	example6.Cancel_Loading_Textures = false
+	example6.Next_Texture_Idx = shared.MISSING_TEXTURE_ID + 1
+
+	delete(example6.Loaded_Textures)
+	example6.Loaded_Textures = nil
+
+	delete(example6.Image_To_Texture)
+	example6.Image_To_Texture = {}
+
+	delete(example6.Image_Uploaded)
+	example6.Image_Uploaded = {}
+}
+
+
+@(test)
+example6_validation_async :: proc(t: ^testing.T) {
+    sync.guard(&test_mutex)
+    reset_example6_static_state()
+    setup_validation_error_hook()
+    example6.Load_Textures_Async = true
+    example6.Total_Max_Frames = 10
+    testing.cleanup(t, proc(_: rawptr) {
+        reset_example6_static_state()
+    }, nil)
+    example6.main()
+    assert_no_validation_errors(t)
+    gpu.cleanup()
+}
+
+@(test)
+example6_validation_sync :: proc(t: ^testing.T) {
+    sync.guard(&test_mutex)
+    reset_example6_static_state()
+    setup_validation_error_hook()
+    example6.Load_Textures_Async = false
+    example6.Total_Max_Frames = 10
+    testing.cleanup(t, proc(_: rawptr) {
+        reset_example6_static_state()
+    }, nil)
+    example6.main()
+    assert_no_validation_errors(t)
+    gpu.cleanup()
+}


### PR DESCRIPTION
Related to #9. This is something I've been thinking for a while. We should easily ensure that we are not breaking stuff when refactoring core.

- This validates that all examples build
- Validates that examples produce no VK validation errors
- I had to tweak how VMA is linked to get it to build on windows with `odin test`. Honestly I'm don't fully understand if this change can break anything, so please verify
- Adds some hooking functionality into gpu_vulkan to enable testing. This would probably be better supplied as arguments into gpu.init, but that would mean hacking way too much on the example code


TODO:
- Add screenshot snapshot testing to verify consistent rendering
- All odin tests run in the same process as threads which is quite inconvenient for no_gfx_api as it has one global static instance. This also messes with statics in examples. I'm not sure how to handle this properly