### PR TITLE
Anisotropic filtering and manual mipmaps

### DIFF
--- a/examples/6_deferred_async_load/main.odin
+++ b/examples/6_deferred_async_load/main.odin
@@ -42,6 +42,9 @@ Num_Async_Worker_Threads := clamp(info.cpu.logical_cores - 1, 2, 6)
 // How many textures to load in a single batch / command buffer
 Loader_Chunk_Size :: 16
 
+// Use CPU block-compressed mip generation instead of GPU mipmaps.
+Compress_Textures :: false
+
 // G-buffer texture indices in texture heap
 GBUFFER_ALBEDO_IDX :: 1000
 GBUFFER_NORMAL_IDX :: 1001
@@ -729,7 +732,7 @@ load_scene_textures_from_gltf :: proc(
 	// that easy, currently.
 	transfer_queue := gpu.get_queue(.Main)
 
-	upload_arena := gpu.arena_init(Loader_Chunk_Size * 4 * 1024 * 1024)
+	upload_arena := gpu.arena_init(Loader_Chunk_Size * 8 * 1024 * 1024)
 	defer gpu.arena_destroy(&upload_arena)
 
 	for info in texture_infos {
@@ -802,10 +805,12 @@ load_scene_textures_from_gltf :: proc(
 			scene.meshes[info.mesh_id].normal_map = texture.texture_idx
 		}
 
+		view_format: gpu.Texture_Format = .RGBA8_Unorm
+		if Compress_Textures do view_format = .BC3_RGBA_Unorm
 		gpu.set_texture_desc(
 			texture_heap,
 			texture.texture_idx,
-			gpu.texture_view_descriptor(texture.texture, {format = .RGBA8_Unorm}),
+			gpu.texture_view_descriptor(texture.texture, {format = view_format}),
 		)
 	}
 }
@@ -874,6 +879,48 @@ load_texture_from_gltf :: proc(
 		return {}
 	}
 	defer image.destroy(img)
+
+	if Compress_Textures {
+		compressed := shared.bc3_compress_rgba8_mips(
+			img.pixels.buf[:],
+			u32(img.width),
+			u32(img.height),
+		)
+		defer {
+			delete(compressed.data)
+			delete(compressed.offsets)
+		}
+
+		staging, staging_gpu := gpu.arena_alloc_untyped(upload_arena, u64(len(compressed.data)))
+		runtime.mem_copy(staging, raw_data(compressed.data), len(compressed.data))
+
+		texture := gpu.alloc_and_create_texture(
+			{
+				type = .D2,
+				dimensions = {u32(img.width), u32(img.height), 1},
+				mip_count = compressed.mip_count,
+				layer_count = 1,
+				sample_count = 1,
+				format = .BC3_RGBA_Unorm,
+				usage = { .Sampled, .Transfer_Src },
+			},
+			queue,
+		)
+		if sync.guard(&mutex) do append(&loaded_textures, texture)
+
+		regions := make([]gpu.Mip_Copy_Region, int(compressed.mip_count))
+		for mip: u32 = 0; mip < compressed.mip_count; mip += 1 {
+			regions[mip] = {
+				src_offset = compressed.offsets[mip],
+				mip_level = mip,
+				array_layer = 0,
+				layer_count = 1,
+			}
+		}
+
+		gpu.cmd_copy_mips_to_texture(cmd_buf, texture, staging_gpu, regions)
+		return texture
+	}
 
 	staging, staging_gpu := gpu.arena_alloc_untyped(upload_arena, u64(len(img.pixels.buf)))
 	runtime.mem_copy(staging, raw_data(img.pixels.buf), len(img.pixels.buf))

--- a/gpu/gpu.odin
+++ b/gpu/gpu.odin
@@ -29,7 +29,21 @@ Allocation_Type :: enum { Default = 0, Descriptors }
 Memory :: enum { Default = 0, GPU, Readback }
 Queue_Type :: enum { Main = 0, Compute, Transfer }
 Texture_Type :: enum { D2 = 0, D3, D1 }
-Texture_Format :: enum { Default = 0, RGBA8_Unorm, RGBA8_SRGB, BGRA8_Unorm, D32_Float, RGBA16_Float }
+Texture_Format :: enum {
+	Default = 0,
+	RGBA8_Unorm,
+	BGRA8_Unorm,
+	D32_Float,
+	RGBA16_Float,
+	BC1_RGBA_Unorm,
+	BC3_RGBA_Unorm,
+	BC7_RGBA_Unorm,
+	ASTC_4x4_RGBA_Unorm,
+	ETC2_RGB8_Unorm,
+	ETC2_RGBA8_Unorm,
+	EAC_R11_Unorm,
+	EAC_RG11_Unorm,
+}
 Usage :: enum { Sampled = 0, Storage, Transfer_Src, Color_Attachment, Depth_Stencil_Attachment }
 Usage_Flags :: bit_set[Usage; u32]
 Shader_Type_Graphics :: enum { Vertex = 0, Fragment }
@@ -66,6 +80,13 @@ Blit_Rect :: struct
     mip_level: u32,
     base_layer: u32,
     layer_count: u32,
+}
+
+Mip_Copy_Region :: struct {
+	src_offset:  u64, // Offset in staging buffer
+	mip_level:   u32,
+	array_layer: u32,
+	layer_count: u32,
 }
 
 Texture_Desc :: struct
@@ -290,6 +311,7 @@ commands_begin: proc(queue: Queue) -> Command_Buffer : _commands_begin
 // Commands
 cmd_mem_copy: proc(cmd_buf: Command_Buffer, src, dst: rawptr, #any_int bytes: i64) : _cmd_mem_copy
 cmd_copy_to_texture: proc(cmd_buf: Command_Buffer, texture: Texture, src, dst: rawptr) : _cmd_copy_to_texture
+cmd_copy_mips_to_texture: proc(cmd_buf: Command_Buffer, texture: Texture, src_buffer: rawptr, regions: []Mip_Copy_Region) : _cmd_copy_mips_to_texture
 cmd_blit_texture: proc(cmd_buf: Command_Buffer, src, dst: Texture, src_rects: []Blit_Rect, dst_rects: []Blit_Rect, filter: Filter) : _cmd_blit_texture
 
 cmd_set_desc_heap: proc(cmd_buf: Command_Buffer, textures, textures_rw, samplers, bvhs: rawptr) : _cmd_set_desc_heap

--- a/gpu/gpu_vulkan.odin
+++ b/gpu/gpu_vulkan.odin
@@ -2024,6 +2024,66 @@ _cmd_blit_texture :: proc(cmd_buf: Command_Buffer, src, dst: Texture, src_rects:
     vk.CmdBlitImage(cmd_buf_info.handle, src_info.handle, .GENERAL, dst_info.handle, .GENERAL, u32(len(regions)), raw_data(regions), vk_filter)
 }
 
+_cmd_copy_mips_to_texture :: proc(
+    cmd_buf: Command_Buffer,
+    texture: Texture,
+    src_buffer: rawptr,
+    regions: []Mip_Copy_Region,
+)
+{
+    sync.lock(&ctx.lock)
+    cmd := get_resource(cmd_buf, ctx.command_buffers)
+    tex_info := get_resource(texture.handle, ctx.textures)
+    sync.unlock(&ctx.lock)
+
+    src_buf, base_offset, ok_s := compute_buf_offset_from_gpu_ptr(src_buffer)
+    if !ok_s {
+        fatal_error("Alloc not found.")
+        return
+    }
+
+    if texture.mip_count < u32(len(regions)) {
+        fatal_error("Texture mip count is less than the number of regions")
+        return
+    }
+
+    plane_aspect: vk.ImageAspectFlags = { .DEPTH } if texture.format == .D32_Float else { .COLOR }
+    is_compressed := is_block_compressed(texture.format)
+
+    scratch, _ := acquire_scratch()
+
+    copies := make([]vk.BufferImageCopy, len(regions), allocator = scratch)
+
+    for region, i in regions {
+        mip_width := max(1, texture.dimensions.x >> region.mip_level)
+        mip_height := max(1, texture.dimensions.y >> region.mip_level)
+        mip_depth := max(1, texture.dimensions.z >> region.mip_level)
+
+        copies[i] = vk.BufferImageCopy{
+            bufferOffset = vk.DeviceSize(u64(base_offset) + region.src_offset),
+            bufferRowLength = 0 if is_compressed else mip_width,
+            bufferImageHeight = 0 if is_compressed else mip_height,
+            imageSubresource = {
+                aspectMask = plane_aspect,
+                mipLevel = region.mip_level,
+                baseArrayLayer = region.array_layer,
+                layerCount = region.layer_count,
+            },
+            imageOffset = {},
+            imageExtent = { mip_width, mip_height, mip_depth },
+        }
+    }
+
+    vk.CmdCopyBufferToImage(
+        cmd.handle,
+        src_buf,
+        tex_info.handle,
+        .GENERAL,
+        cast(u32) len(copies),
+        raw_data(copies),
+    )
+}
+
 _cmd_set_desc_heap :: proc(cmd_buf: Command_Buffer, textures, textures_rw, samplers, bvhs: rawptr)
 {
     sync.lock(&ctx.lock)
@@ -3213,13 +3273,39 @@ to_vk_texture_format :: proc(format: Texture_Format) -> vk.Format
     switch format
     {
         case .Default: panic("Implementation bug!")
-        case .RGBA8_Unorm:  return .R8G8B8A8_UNORM
-        case .RGBA8_SRGB:   return .R8G8B8A8_SRGB
-        case .BGRA8_Unorm:  return .B8G8R8A8_UNORM
-        case .D32_Float:    return .D32_SFLOAT
+        case .RGBA8_Unorm: return .R8G8B8A8_UNORM
+        case .BGRA8_Unorm: return .B8G8R8A8_UNORM
+        case .D32_Float: return .D32_SFLOAT
         case .RGBA16_Float: return .R16G16B16A16_SFLOAT
+        case .BC1_RGBA_Unorm: return .BC1_RGBA_UNORM_BLOCK
+        case .BC3_RGBA_Unorm: return .BC3_UNORM_BLOCK
+        case .BC7_RGBA_Unorm: return .BC7_UNORM_BLOCK
+        case .ASTC_4x4_RGBA_Unorm: return .ASTC_4x4_UNORM_BLOCK
+        case .ETC2_RGB8_Unorm: return .ETC2_R8G8B8_UNORM_BLOCK
+        case .ETC2_RGBA8_Unorm: return .ETC2_R8G8B8A8_UNORM_BLOCK
+        case .EAC_R11_Unorm: return .EAC_R11_UNORM_BLOCK
+        case .EAC_RG11_Unorm: return .EAC_R11G11_UNORM_BLOCK
     }
     return {}
+}
+
+@(private="file")
+is_block_compressed :: #force_inline proc(format: Texture_Format) -> bool
+{
+    #partial switch format
+    {
+        case .BC1_RGBA_Unorm,
+             .BC3_RGBA_Unorm,
+             .BC7_RGBA_Unorm,
+             .ASTC_4x4_RGBA_Unorm,
+             .ETC2_RGB8_Unorm,
+             .ETC2_RGBA8_Unorm,
+             .EAC_R11_Unorm,
+             .EAC_RG11_Unorm:
+            return true
+    }
+
+    return false
 }
 
 @(private="file")


### PR DESCRIPTION
- Adds option to use anisotropic filtering so that the mipmaps aren't blurry in the distance
- Adds helper which returns max anisotropy (and perhaps other stuff in the future)
- Adds support for compressed texture formats
- Adds support for uploading mipmaps from the CPU which is needed for compressed textures
- Adds simplest bc3 compression I could find to the example6 so that we can verify that the codepath works