### PR TITLE
Improve slice API

### DIFF
--- a/examples/1_triangle/main.odin
+++ b/examples/1_triangle/main.odin
@@ -59,19 +59,14 @@ main :: proc()
     verts.cpu[0].pos = { -0.5,  0.5, 0.0 }
     verts.cpu[1].pos = {  0.0, -0.5, 0.0 }
     verts.cpu[2].pos = {  0.5,  0.5, 0.0 }
-    // verts.cpu[3].pos = {  -0.5,  -0.5, 0.0 }
     verts.cpu[0].color = { 1.0, 0.0, 0.0 }
     verts.cpu[1].color = { 0.0, 1.0, 0.0 }
     verts.cpu[2].color = { 0.0, 0.0, 1.0 }
-    // verts.cpu[3].color = { 0.0, 0.0, 1.0 }
 
     indices := gpu.arena_alloc(&arena, u32, 3)
     indices.cpu[0] = 0
     indices.cpu[1] = 2
     indices.cpu[2] = 1
-    // indices.cpu[3+0] = 0
-    // indices.cpu[3+1] = 3
-    // indices.cpu[3+2] = 1
 
     verts_local := gpu.mem_alloc(Vertex, 3, gpu.Memory.GPU)
     indices_local := gpu.mem_alloc(u32, 3, gpu.Memory.GPU)
@@ -81,8 +76,8 @@ main :: proc()
     }
 
     upload_cmd_buf := gpu.commands_begin(.Main)
-    gpu.cmd_mem_copy(upload_cmd_buf, verts_local, verts, len(verts.cpu))
-    gpu.cmd_mem_copy(upload_cmd_buf, indices_local, indices, len(indices.cpu))
+    gpu.cmd_mem_copy(upload_cmd_buf, verts_local, verts)
+    gpu.cmd_mem_copy(upload_cmd_buf, indices_local, indices)
     gpu.cmd_barrier(upload_cmd_buf, .Transfer, .All, {})
     gpu.queue_submit(.Main, { upload_cmd_buf })
 

--- a/examples/1_triangle/main.odin
+++ b/examples/1_triangle/main.odin
@@ -59,14 +59,19 @@ main :: proc()
     verts.cpu[0].pos = { -0.5,  0.5, 0.0 }
     verts.cpu[1].pos = {  0.0, -0.5, 0.0 }
     verts.cpu[2].pos = {  0.5,  0.5, 0.0 }
+    // verts.cpu[3].pos = {  -0.5,  -0.5, 0.0 }
     verts.cpu[0].color = { 1.0, 0.0, 0.0 }
     verts.cpu[1].color = { 0.0, 1.0, 0.0 }
     verts.cpu[2].color = { 0.0, 0.0, 1.0 }
+    // verts.cpu[3].color = { 0.0, 0.0, 1.0 }
 
     indices := gpu.arena_alloc(&arena, u32, 3)
     indices.cpu[0] = 0
     indices.cpu[1] = 2
     indices.cpu[2] = 1
+    // indices.cpu[3+0] = 0
+    // indices.cpu[3+1] = 3
+    // indices.cpu[3+2] = 1
 
     verts_local := gpu.mem_alloc(Vertex, 3, gpu.Memory.GPU)
     indices_local := gpu.mem_alloc(u32, 3, gpu.Memory.GPU)
@@ -131,7 +136,7 @@ main :: proc()
         verts_data := gpu.arena_alloc(frame_arena, Vert_Data)
         verts_data.cpu^ = { verts = verts_local.gpu.ptr }
 
-        gpu.cmd_draw_indexed_instanced(cmd_buf, verts_data, {}, indices_local, 3, 1)
+        gpu.cmd_draw_indexed(cmd_buf, verts_data, {}, indices_local)
         gpu.cmd_end_render_pass(cmd_buf)
         gpu.cmd_add_signal_semaphore(cmd_buf, frame_sem, next_frame)
         gpu.queue_submit(.Main, { cmd_buf })

--- a/examples/2_textures/main.odin
+++ b/examples/2_textures/main.odin
@@ -222,7 +222,7 @@ load_texture :: proc(bytes: []byte, upload_arena: ^gpu.Arena, cmd_buf: gpu.Comma
         format = .RGBA8_Unorm,
         usage = { .Sampled },
     })
-    gpu.cmd_copy_to_texture(cmd_buf, texture, staging.gpu, texture.mem)
+    gpu.cmd_copy_to_texture(cmd_buf, texture, staging.gpu)
     return texture
 }
 

--- a/examples/2_textures/main.odin
+++ b/examples/2_textures/main.odin
@@ -99,8 +99,8 @@ main :: proc()
         gpu.texture_free_and_destroy(&peach_tex)
         gpu.texture_free_and_destroy(&bowser_tex)
     }
-    gpu.cmd_mem_copy(upload_cmd_buf, verts_local, verts, len(verts.cpu))
-    gpu.cmd_mem_copy(upload_cmd_buf, indices_local, indices, len(indices.cpu))
+    gpu.cmd_mem_copy(upload_cmd_buf, verts_local, verts)
+    gpu.cmd_mem_copy(upload_cmd_buf, indices_local, indices)
     gpu.cmd_barrier(upload_cmd_buf, .Transfer, .All, {})
 
     gpu.queue_submit(.Main, { upload_cmd_buf })

--- a/examples/2_textures/main.odin
+++ b/examples/2_textures/main.odin
@@ -171,7 +171,7 @@ main :: proc()
         frag_data.cpu.sampler = linear_sampler
         frag_data.cpu.fade = changing_fade(delta_time)
 
-        gpu.cmd_draw_indexed_instanced(cmd_buf, verts_data.gpu, frag_data.gpu, indices_local, u32(len(indices.cpu)), 1)
+        gpu.cmd_draw_indexed(cmd_buf, verts_data, frag_data, indices_local)
         gpu.cmd_end_render_pass(cmd_buf)
         gpu.cmd_add_signal_semaphore(cmd_buf, frame_sem, next_frame)
         gpu.queue_submit(.Main, { cmd_buf })

--- a/examples/2_textures/main.odin
+++ b/examples/2_textures/main.odin
@@ -1,4 +1,6 @@
 
+#+vet !unused-imports
+
 package main
 
 import log "core:log"
@@ -222,14 +224,9 @@ load_texture :: proc(bytes: []byte, upload_arena: ^gpu.Arena, cmd_buf: gpu.Comma
         format = .RGBA8_Unorm,
         usage = { .Sampled },
     })
-    gpu.cmd_copy_to_texture(cmd_buf, texture, staging.gpu)
+    gpu.cmd_copy_to_texture(cmd_buf, texture, staging)
     return texture
 }
-
-// To get around the fact that I need to import "core:image/png" to load pngs,
-// but then -vet complains because it's not used.
-@(private="file")
-_fictitious :: proc() -> png.Error { return {} }
 
 changing_fade :: proc(delta_time: f32) -> f32
 {

--- a/examples/3_3D/main.odin
+++ b/examples/3_3D/main.odin
@@ -212,10 +212,10 @@ upload_mesh :: proc(upload_arena: ^gpu.Arena, cmd_buf: gpu.Command_Buffer, mesh:
     res.normals = gpu.mem_alloc([4]f32, len(mesh.normals), gpu.Memory.GPU)
     res.uvs = gpu.mem_alloc([2]f32, len(mesh.uvs), gpu.Memory.GPU)
     res.indices = gpu.mem_alloc(u32, len(mesh.indices), gpu.Memory.GPU)
-    gpu.cmd_mem_copy(cmd_buf, res.pos, positions_staging, len(mesh.pos))
-    gpu.cmd_mem_copy(cmd_buf, res.normals, normals_staging, len(mesh.normals))
-    gpu.cmd_mem_copy(cmd_buf, res.uvs, uvs_staging, len(mesh.uvs))
-    gpu.cmd_mem_copy(cmd_buf, res.indices, indices_staging, len(mesh.indices))
+    gpu.cmd_mem_copy(cmd_buf, res.pos, positions_staging)
+    gpu.cmd_mem_copy(cmd_buf, res.normals, normals_staging)
+    gpu.cmd_mem_copy(cmd_buf, res.uvs, uvs_staging)
+    gpu.cmd_mem_copy(cmd_buf, res.indices, indices_staging)
     return res
 }
 

--- a/examples/3_3D/main.odin
+++ b/examples/3_3D/main.odin
@@ -161,7 +161,6 @@ main :: proc()
                 world_to_view: [16]f32,
                 view_to_proj: [16]f32,
             }
-            #assert(size_of(Vert_Data) == 8+8+64+64+64+64)
             verts_data := gpu.arena_alloc(frame_arena, Vert_Data)
             verts_data.cpu^ = {
                 positions = mesh.pos.gpu.ptr,
@@ -172,7 +171,7 @@ main :: proc()
                 view_to_proj = intr.matrix_flatten(view_to_proj),
             }
 
-            gpu.cmd_draw_indexed_instanced(cmd_buf, verts_data.gpu, {}, mesh.indices, mesh.idx_count, 1)
+            gpu.cmd_draw_indexed(cmd_buf, verts_data, {}, mesh.indices)
         }
 
         gpu.cmd_end_render_pass(cmd_buf)
@@ -192,7 +191,6 @@ Mesh_GPU :: struct
     normals: gpu.slice_t([4]f32),
     uvs: gpu.slice_t([2]f32),
     indices: gpu.slice_t(u32),
-    idx_count: u32,
 }
 
 upload_mesh :: proc(upload_arena: ^gpu.Arena, cmd_buf: gpu.Command_Buffer, mesh: shared.Mesh) -> Mesh_GPU
@@ -214,7 +212,6 @@ upload_mesh :: proc(upload_arena: ^gpu.Arena, cmd_buf: gpu.Command_Buffer, mesh:
     res.normals = gpu.mem_alloc([4]f32, len(mesh.normals), gpu.Memory.GPU)
     res.uvs = gpu.mem_alloc([2]f32, len(mesh.uvs), gpu.Memory.GPU)
     res.indices = gpu.mem_alloc(u32, len(mesh.indices), gpu.Memory.GPU)
-    res.idx_count = u32(len(mesh.indices))
     gpu.cmd_mem_copy(cmd_buf, res.pos, positions_staging, len(mesh.pos))
     gpu.cmd_mem_copy(cmd_buf, res.normals, normals_staging, len(mesh.normals))
     gpu.cmd_mem_copy(cmd_buf, res.uvs, uvs_staging, len(mesh.uvs))

--- a/examples/4_indirect_triangles/main.odin
+++ b/examples/4_indirect_triangles/main.odin
@@ -129,10 +129,10 @@ main :: proc()
     }
 
     upload_cmd_buf := gpu.commands_begin(.Main)
-    gpu.cmd_mem_copy(upload_cmd_buf, verts_local, verts, len(verts.cpu))
-    gpu.cmd_mem_copy(upload_cmd_buf, indices_local, indices, len(indices.cpu))
+    gpu.cmd_mem_copy(upload_cmd_buf, verts_local, verts)
+    gpu.cmd_mem_copy(upload_cmd_buf, indices_local, indices)
     gpu.cmd_mem_copy(upload_cmd_buf, count_local, count)
-    gpu.cmd_mem_copy(upload_cmd_buf, indirect_data_local, indirect_data, Num_Triangles)
+    gpu.cmd_mem_copy(upload_cmd_buf, indirect_data_local, indirect_data)
     gpu.cmd_barrier(upload_cmd_buf, .Transfer, .All, {})
     gpu.queue_submit(.Main, { upload_cmd_buf })
 
@@ -196,7 +196,7 @@ main :: proc()
             //   indirect_data_local: GPU pointer to array of IndirectData (contains both draw command and per-draw data)
             //   stride: Byte stride between elements in the indirect data array (size of IndirectData struct)
             //   count_local: GPU pointer to u32 containing the number of draws to execute
-            gpu.cmd_draw_indexed_indirect_multi(cmd_buf, shared_vert_data, {}, indices_local, indirect_data_local, u32(size_of(IndirectData)), count_local)
+            gpu.cmd_draw_indexed_indirect_multi(cmd_buf, shared_vert_data, {}, indices_local, indirect_data_local, count_local)
         } else {
             // Renders only the first draw from the indirect data buffer
             gpu.cmd_draw_indexed_indirect(cmd_buf, shared_vert_data, {}, indices_local, indirect_data_local)

--- a/examples/4_indirect_triangles/main.odin
+++ b/examples/4_indirect_triangles/main.odin
@@ -72,14 +72,14 @@ main :: proc()
     indices_local := gpu.mem_alloc(u32, 3, gpu.Memory.GPU)
 
     // Unified indirect data struct that extends Draw_Indexed_Indirect_Command
-    IndirectData :: struct {
+    Indirect_Data :: struct {
         using cmd: gpu.Draw_Indexed_Indirect_Command,
         color: [3]f32,
         pos: [3]f32,
         size: f32,
     }
 
-    indirect_data := gpu.mem_alloc(IndirectData, Num_Triangles)
+    indirect_data := gpu.mem_alloc(Indirect_Data, Num_Triangles)
     defer gpu.mem_free(indirect_data)
 
     count := gpu.arena_alloc(&arena, u32)
@@ -105,7 +105,7 @@ main :: proc()
         rgb := hsl_to_rgb(hue, saturation, lightness)
 
         // Fill unified indirect data struct with both command and user data
-        indirect_data.cpu[i] = IndirectData {
+        indirect_data.cpu[i] = Indirect_Data {
             cmd = gpu.Draw_Indexed_Indirect_Command {
                 index_count = 3,
                 instance_count = 1,
@@ -119,7 +119,7 @@ main :: proc()
         }
     }
 
-    indirect_data_local := gpu.mem_alloc(IndirectData, Num_Triangles, gpu.Memory.GPU)
+    indirect_data_local := gpu.mem_alloc(Indirect_Data, Num_Triangles, gpu.Memory.GPU)
 
     defer {
         gpu.mem_free(verts_local)

--- a/examples/4_indirect_triangles/main.odin
+++ b/examples/4_indirect_triangles/main.odin
@@ -196,10 +196,10 @@ main :: proc()
             //   indirect_data_local: GPU pointer to array of IndirectData (contains both draw command and per-draw data)
             //   stride: Byte stride between elements in the indirect data array (size of IndirectData struct)
             //   count_local: GPU pointer to u32 containing the number of draws to execute
-            gpu.cmd_draw_indexed_instanced_indirect_multi(cmd_buf, shared_vert_data.gpu, {}, indices_local, indirect_data_local, u32(size_of(IndirectData)), count_local)
+            gpu.cmd_draw_indexed_indirect_multi(cmd_buf, shared_vert_data, {}, indices_local, indirect_data_local, u32(size_of(IndirectData)), count_local)
         } else {
             // Renders only the first draw from the indirect data buffer
-            gpu.cmd_draw_indexed_instanced_indirect(cmd_buf, shared_vert_data.gpu, {}, indices_local, indirect_data_local)
+            gpu.cmd_draw_indexed_indirect(cmd_buf, shared_vert_data, {}, indices_local, indirect_data_local)
         }
 
         gpu.cmd_end_render_pass(cmd_buf)

--- a/examples/5_compute_shaders/main.odin
+++ b/examples/5_compute_shaders/main.odin
@@ -120,8 +120,8 @@ main :: proc()
     }
 
     upload_cmd_buf := gpu.commands_begin(.Main)
-    gpu.cmd_mem_copy(upload_cmd_buf, verts_local, verts, len(verts.cpu))
-    gpu.cmd_mem_copy(upload_cmd_buf, indices_local, indices, len(indices.cpu))
+    gpu.cmd_mem_copy(upload_cmd_buf, verts_local, verts)
+    gpu.cmd_mem_copy(upload_cmd_buf, indices_local, indices)
     gpu.cmd_barrier(upload_cmd_buf, .Transfer, .All, {})
     gpu.queue_submit(.Main, { upload_cmd_buf })
 

--- a/examples/5_compute_shaders/main.odin
+++ b/examples/5_compute_shaders/main.odin
@@ -200,9 +200,9 @@ main :: proc()
                 num_groups_z,
             }
 
-            gpu.cmd_dispatch_indirect(cmd_buf, compute_data.gpu, indirect_dispatch_command)
+            gpu.cmd_dispatch_indirect(cmd_buf, compute_data, indirect_dispatch_command)
         } else {
-            gpu.cmd_dispatch(cmd_buf, compute_data.gpu, num_groups_x, num_groups_y, num_groups_z)
+            gpu.cmd_dispatch(cmd_buf, compute_data, num_groups_x, num_groups_y, num_groups_z)
         }
 
         // Barrier to ensure compute shader finishes before rendering

--- a/examples/5_compute_shaders/main.odin
+++ b/examples/5_compute_shaders/main.odin
@@ -230,7 +230,7 @@ main :: proc()
         frag_data.cpu.texture_id = texture_id
         frag_data.cpu.sampler_id = sampler_id
 
-        gpu.cmd_draw_indexed_instanced(cmd_buf, verts_data.gpu, frag_data.gpu, indices_local, u32(len(indices.cpu)), 1)
+        gpu.cmd_draw_indexed(cmd_buf, verts_data, frag_data, indices_local)
         gpu.cmd_end_render_pass(cmd_buf)
         gpu.cmd_add_signal_semaphore(cmd_buf, frame_sem, next_frame)
         gpu.queue_submit(.Main, { cmd_buf })

--- a/examples/6_deferred_async_load/main.odin
+++ b/examples/6_deferred_async_load/main.odin
@@ -596,7 +596,7 @@ create_magenta_texture :: proc(
 			usage = {.Sampled},
 		},
 	)
-	gpu.cmd_copy_to_texture(cmd_buf, texture, staging, texture.mem)
+	gpu.cmd_copy_to_texture(cmd_buf, texture, staging)
 	return texture
 }
 
@@ -772,7 +772,7 @@ upload_texture :: proc(
 	{
 		// Upload texture to GPU
 		upload_cmd_buf := gpu.commands_begin(.Transfer)
-		gpu.cmd_copy_to_texture(upload_cmd_buf, texture, staging, texture.mem)
+		gpu.cmd_copy_to_texture(upload_cmd_buf, texture, staging)
 		gpu.cmd_add_signal_semaphore(upload_cmd_buf, upload_sem, upload_sem_value_old + 1)
 		gpu.queue_submit(.Transfer, {upload_cmd_buf})
 	}

--- a/examples/6_deferred_async_load/main.odin
+++ b/examples/6_deferred_async_load/main.odin
@@ -637,13 +637,11 @@ create_fullscreen_quad :: proc(
 		cmd_buf,
 		full_screen_quad_verts_local,
 		fsq_verts,
-		len(fsq_verts.cpu),
 	)
 	gpu.cmd_mem_copy(
 		cmd_buf,
 		full_screen_quad_indices_local,
 		fsq_indices,
-		len(fsq_indices.cpu),
 	)
 
 	return full_screen_quad_verts_local, full_screen_quad_indices_local
@@ -908,10 +906,10 @@ upload_mesh :: proc(upload_arena: ^gpu.Arena, cmd_buf: gpu.Command_Buffer, mesh:
 	res.uvs = gpu.mem_alloc([2]f32, len(mesh.uvs), mem_type = gpu.Memory.GPU)
 	res.indices = gpu.mem_alloc(u32, len(mesh.indices), mem_type = gpu.Memory.GPU)
 	res.idx_count = u32(len(mesh.indices))
-	gpu.cmd_mem_copy(cmd_buf, res.pos,     positions_staging, len(mesh.pos))
-	gpu.cmd_mem_copy(cmd_buf, res.normals, normals_staging,   len(mesh.normals))
-	gpu.cmd_mem_copy(cmd_buf, res.uvs,     uvs_staging,       len(mesh.uvs))
-	gpu.cmd_mem_copy(cmd_buf, res.indices, indices_staging,   len(mesh.indices))
+	gpu.cmd_mem_copy(cmd_buf, res.pos,     positions_staging)
+	gpu.cmd_mem_copy(cmd_buf, res.normals, normals_staging  )
+	gpu.cmd_mem_copy(cmd_buf, res.uvs,     uvs_staging      )
+	gpu.cmd_mem_copy(cmd_buf, res.indices, indices_staging  )
 	return res
 }
 

--- a/examples/6_deferred_async_load/main.odin
+++ b/examples/6_deferred_async_load/main.odin
@@ -450,13 +450,11 @@ render_pass_gbuffer :: proc(
 			normal_map_sampler             = sampler_id,
 		}
 
-		gpu.cmd_draw_indexed_instanced(
+		gpu.cmd_draw_indexed(
 			cmd_buf,
 			verts_data.gpu,
 			frag_data.gpu,
 			mesh.indices,
-			mesh.idx_count,
-			1,
 		)
 	}
 
@@ -515,7 +513,7 @@ render_pass_final :: proc(
 	}
 
 	// Render fullscreen quad
-	gpu.cmd_draw_indexed_instanced(cmd_buf, verts_data.gpu, frag_data.gpu, fsq_indices, 6, 1)
+	gpu.cmd_draw_indexed(cmd_buf, verts_data.gpu, frag_data.gpu, fsq_indices)
 
 	gpu.cmd_end_render_pass(cmd_buf)
 }

--- a/examples/6_deferred_async_load/main.odin
+++ b/examples/6_deferred_async_load/main.odin
@@ -788,8 +788,8 @@ upload_texture :: proc(
 			delete(compressed.offsets)
 		}
 
-		staging := gpu.arena_alloc_raw(upload_arena, len(compressed.data), 1, 16)
-		runtime.mem_copy(staging.cpu, raw_data(compressed.data), len(compressed.data))
+		staging := gpu.arena_alloc(upload_arena, u8, len(compressed.data))
+		copy(staging.cpu, compressed.data[:])
 
 		texture = gpu.texture_alloc_and_create(
 			{
@@ -805,23 +805,18 @@ upload_texture :: proc(
 		)
 		append(&loaded_textures, texture)
 
-		regions := make([]gpu.Mip_Copy_Region, int(compressed.mip_count))
-		for mip: u32 = 0; mip < compressed.mip_count; mip += 1 {
-			regions[mip] = {
-				src_offset = compressed.offsets[mip],
-				mip_level = mip,
-				array_layer = 0,
-				layer_count = 1,
-			}
-		}
-
 		upload_cmd_buf := gpu.commands_begin(.Transfer)
         gpu.cmd_barrier(upload_cmd_buf, .Transfer, .Transfer, {})
-		gpu.cmd_copy_mips_to_texture(upload_cmd_buf, texture, staging, regions)
+        for mip in 0..<compressed.mip_count {
+        	gpu.cmd_copy_to_texture(
+        		upload_cmd_buf,
+        		texture,
+        		gpu.subslice(staging, compressed.offsets[mip]),
+        		{ mip_level = mip }
+        	)
+        }
 		gpu.cmd_add_wait_semaphore(upload_cmd_buf, upload_sem, upload_sem_value_old + 1)
 		gpu.queue_submit(.Transfer, {upload_cmd_buf})
-
-		return texture
 	} else {
 		// Generate mipmaps
 		mipmaps_cmd_buf := gpu.commands_begin(.Main)
@@ -845,8 +840,8 @@ upload_bc3_texture :: proc(
 	upload_sem_val += 1
 
     upload_cmd_buf := gpu.commands_begin(.Transfer)
-    staging := gpu.arena_alloc_raw(upload_arena, len(compressed.data), 1, 16)
-    runtime.mem_copy(staging.cpu, raw_data(compressed.data), len(compressed.data))
+    staging := gpu.arena_alloc(upload_arena, u8, len(compressed.data))
+    copy(staging.cpu, compressed.data[:])
 
     texture := gpu.texture_alloc_and_create(
         {
@@ -860,17 +855,14 @@ upload_bc3_texture :: proc(
     )
     append(&loaded_textures, texture)
 
-    regions := make([]gpu.Mip_Copy_Region, int(compressed.mip_count))
-    for mip: u32 = 0; mip < compressed.mip_count; mip += 1 {
-        regions[mip] = {
-            src_offset = compressed.offsets[mip],
-            mip_level = mip,
-            array_layer = 0,
-            layer_count = 1,
-        }
+    for mip in 0..<compressed.mip_count {
+    	gpu.cmd_copy_to_texture(
+    		upload_cmd_buf,
+    		texture,
+    		gpu.subslice(staging, compressed.offsets[mip]),
+    		{ mip_level = mip }
+    	)
     }
-
-    gpu.cmd_copy_mips_to_texture(upload_cmd_buf, texture, staging, regions)
     gpu.cmd_barrier(upload_cmd_buf, .Transfer, .Transfer, {})
     gpu.cmd_add_signal_semaphore(upload_cmd_buf, upload_sem, upload_sem_value_old + 1)
     gpu.queue_submit(.Transfer, {upload_cmd_buf})

--- a/examples/6_deferred_async_load/main.odin
+++ b/examples/6_deferred_async_load/main.odin
@@ -452,8 +452,8 @@ render_pass_gbuffer :: proc(
 
 		gpu.cmd_draw_indexed(
 			cmd_buf,
-			verts_data.gpu,
-			frag_data.gpu,
+			verts_data,
+			frag_data,
 			mesh.indices,
 		)
 	}

--- a/examples/7_raytracing/main.odin
+++ b/examples/7_raytracing/main.odin
@@ -139,8 +139,8 @@ main :: proc()
     }
 
     upload_cmd_buf := gpu.commands_begin(.Main)
-    gpu.cmd_mem_copy(upload_cmd_buf, verts_local, verts, len(verts.cpu))
-    gpu.cmd_mem_copy(upload_cmd_buf, indices_local, indices, len(indices.cpu))
+    gpu.cmd_mem_copy(upload_cmd_buf, verts_local, verts)
+    gpu.cmd_mem_copy(upload_cmd_buf, indices_local, indices)
 
     scene := upload_scene(gltf_scene, &upload_arena, &bvh_scratch_arena, upload_cmd_buf)
     defer {
@@ -316,10 +316,10 @@ upload_mesh :: proc(upload_arena: ^gpu.Arena, cmd_buf: gpu.Command_Buffer, mesh:
     res.normals = gpu.mem_alloc([4]f32, len(mesh.normals), mem_type = gpu.Memory.GPU)
     //res.uvs = gpu.mem_alloc([2]f32, len(mesh.uvs), mem_type = gpu.Memory.GPU)
     res.indices = gpu.mem_alloc(u32, len(mesh.indices), mem_type = gpu.Memory.GPU)
-    gpu.cmd_mem_copy(cmd_buf, res.pos, positions_staging, len(mesh.pos))
-    gpu.cmd_mem_copy(cmd_buf, res.normals, normals_staging, len(mesh.normals))
-    //gpu.cmd_mem_copy(cmd_buf, res.uvs, uvs_staging, len(mesh.uvs))
-    gpu.cmd_mem_copy(cmd_buf, res.indices, indices_staging, len(mesh.indices))
+    gpu.cmd_mem_copy(cmd_buf, res.pos, positions_staging)
+    gpu.cmd_mem_copy(cmd_buf, res.normals, normals_staging)
+    //gpu.cmd_mem_copy(cmd_buf, res.uvs, uvs_staging)
+    gpu.cmd_mem_copy(cmd_buf, res.indices, indices_staging)
 
     res.idx_count = u32(len(mesh.indices))
     res.vert_count = u32(len(mesh.pos))
@@ -381,7 +381,7 @@ upload_bvh_instances :: proc(upload_arena: ^gpu.Arena, cmd_buf: gpu.Command_Buff
         }
     }
     instances_local := gpu.mem_alloc(gpu.BVH_Instance, len(instances), mem_type = gpu.Memory.GPU)
-    gpu.cmd_mem_copy(cmd_buf, instances_local, instances_staging, len(instances_staging.cpu))
+    gpu.cmd_mem_copy(cmd_buf, instances_local, instances_staging)
     return instances_local
 }
 
@@ -424,7 +424,7 @@ upload_scene :: proc(scene: shared.Scene, upload_arena: ^gpu.Arena, bvh_scratch_
         instance = { mesh_idx = scene.instances[i].mesh_idx }
     }
     res.instances = gpu.mem_alloc(Instance_Shader, len(scene.instances), gpu.Memory.GPU)
-    gpu.cmd_mem_copy(cmd_buf, res.instances, instances_gpu, len(scene.instances))
+    gpu.cmd_mem_copy(cmd_buf, res.instances, instances_gpu)
 
     meshes_gpu := gpu.arena_alloc(upload_arena, Mesh_Shader, len(scene.meshes))
     for &mesh, i in meshes_gpu.cpu {
@@ -433,7 +433,7 @@ upload_scene :: proc(scene: shared.Scene, upload_arena: ^gpu.Arena, bvh_scratch_
         mesh.indices = res.meshes[i].indices.gpu.ptr
     }
     res.meshes_shader = gpu.mem_alloc(Mesh_Shader, len(scene.meshes), gpu.Memory.GPU)
-    gpu.cmd_mem_copy(cmd_buf, res.meshes_shader, meshes_gpu, len(scene.meshes))
+    gpu.cmd_mem_copy(cmd_buf, res.meshes_shader, meshes_gpu)
 
     // Build BVHs
     gpu.cmd_barrier(cmd_buf, .Transfer, .Build_BVH)

--- a/examples/7_raytracing/main.odin
+++ b/examples/7_raytracing/main.odin
@@ -351,7 +351,7 @@ build_blas :: proc(bvh_scratch_arena: ^gpu.Arena, cmd_buf: gpu.Command_Buffer, p
     }
     bvh := gpu.bvh_alloc_and_create(desc)
     scratch := gpu.bvh_alloc_build_scratch_buffer(bvh_scratch_arena, desc)
-    gpu.cmd_build_blas(cmd_buf, bvh, bvh.mem, scratch, { gpu.BVH_Mesh { verts = positions.gpu.ptr, indices = indices.gpu.ptr } })
+    gpu.cmd_build_blas(cmd_buf, bvh, scratch, { gpu.BVH_Mesh { verts = positions.gpu.ptr, indices = indices.gpu.ptr } })
     return bvh
 }
 
@@ -363,7 +363,7 @@ build_tlas :: proc(bvh_scratch_arena: ^gpu.Arena, cmd_buf: gpu.Command_Buffer, i
     }
     bvh := gpu.bvh_alloc_and_create(desc)
     scratch := gpu.bvh_alloc_build_scratch_buffer(bvh_scratch_arena, desc)
-    gpu.cmd_build_tlas(cmd_buf, bvh, bvh.mem, scratch, instances)
+    gpu.cmd_build_tlas(cmd_buf, bvh, scratch, instances)
     return bvh
 }
 

--- a/examples/7_raytracing/main.odin
+++ b/examples/7_raytracing/main.odin
@@ -239,7 +239,7 @@ main :: proc()
             num_groups_y := (u32(window_size_y) + group_size_y - 1) / group_size_y
             num_groups_z := u32(1)
 
-            gpu.cmd_dispatch(cmd_buf, compute_data.gpu, num_groups_x, num_groups_y, num_groups_z)
+            gpu.cmd_dispatch(cmd_buf, compute_data, num_groups_x, num_groups_y, num_groups_z)
 
             // Barrier to ensure compute shader finishes before rendering
             gpu.cmd_barrier(cmd_buf, .Compute, .Fragment_Shader, {})

--- a/examples/7_raytracing/main.odin
+++ b/examples/7_raytracing/main.odin
@@ -267,7 +267,7 @@ main :: proc()
         frag_data.cpu.texture_id = texture_id
         frag_data.cpu.sampler_id = sampler_id
 
-        gpu.cmd_draw_indexed_instanced(cmd_buf, verts_data.gpu, frag_data.gpu, indices_local, u32(len(indices.cpu)), 1)
+        gpu.cmd_draw_indexed(cmd_buf, verts_data, frag_data, indices_local)
         gpu.cmd_end_render_pass(cmd_buf)
         gpu.cmd_add_signal_semaphore(cmd_buf, frame_sem, next_frame)
         gpu.queue_submit(.Main, { cmd_buf })

--- a/examples/third_party/dear_imgui/main.odin
+++ b/examples/third_party/dear_imgui/main.odin
@@ -90,8 +90,8 @@ main :: proc()
     sampler_id := gpu.desc_pool_alloc_sampler(&desc_pool, gpu.sampler_descriptor({}))
 
     upload_cmd_buf := gpu.commands_begin(.Main)
-    gpu.cmd_mem_copy(upload_cmd_buf, verts_local, verts, 3)
-    gpu.cmd_mem_copy(upload_cmd_buf, indices_local, indices, 3)
+    gpu.cmd_mem_copy(upload_cmd_buf, verts_local, verts)
+    gpu.cmd_mem_copy(upload_cmd_buf, indices_local, indices)
     gpu.cmd_barrier(upload_cmd_buf, .Transfer, .All, {})
     gpu.queue_submit(.Main, { upload_cmd_buf })
 

--- a/examples/third_party/dear_imgui/main.odin
+++ b/examples/third_party/dear_imgui/main.odin
@@ -171,7 +171,7 @@ main :: proc()
         }
         verts_data := gpu.arena_alloc(frame_arena, Vert_Data)
         verts_data.cpu.verts = verts_local.gpu.ptr
-        gpu.cmd_draw_indexed_instanced(cmd_buf, verts_data.gpu, {}, indices_local, 3, 1)
+        gpu.cmd_draw_indexed(cmd_buf, verts_data.gpu, {}, indices_local)
 
         // Render ImGui on top
         draw_data := imgui.get_draw_data()

--- a/examples/third_party/dear_imgui/odin-imgui/imgui_impl_nogfx/imgui_impl_nogfx.odin
+++ b/examples/third_party/dear_imgui/odin-imgui/imgui_impl_nogfx/imgui_impl_nogfx.odin
@@ -289,7 +289,7 @@ create_fonts_texture :: proc(desc_pool: ^gpu.Descriptor_Pool)
         format = .RGBA8_Unorm,
         usage = { .Sampled },
     })
-    gpu.cmd_copy_to_texture(cmd_buf, bd.fonts_texture, staging, bd.fonts_texture.mem)
+    gpu.cmd_copy_to_texture(cmd_buf, bd.fonts_texture, staging)
 
     bd.fonts_texture_id = gpu.desc_pool_alloc_texture(desc_pool, gpu.texture_view_descriptor(bd.fonts_texture, {}))
 

--- a/examples/third_party/dear_imgui/odin-imgui/imgui_impl_nogfx/imgui_impl_nogfx.odin
+++ b/examples/third_party/dear_imgui/odin-imgui/imgui_impl_nogfx/imgui_impl_nogfx.odin
@@ -246,9 +246,8 @@ render_draw_data :: proc(draw_data: ^im.Draw_Data, cmd_buf: gpu.Command_Buffer)
                     tex_id = u32(im.draw_cmd_get_tex_id(pcmd)),
                     sampler_id = render_state.sampler_current_id,
                 }
-                indices_shifted := indices
-                indices_shifted = gpu.subslice(indices_shifted, pcmd.idx_offset)
-                gpu.cmd_draw_indexed(cmd_buf, vert_data, frag_data, gpu.subslice(indices_shifted, 0, pcmd.elem_count))
+                offset_start := i32(pcmd.idx_offset) + global_idx_offset
+                gpu.cmd_draw_indexed(cmd_buf, vert_data, frag_data, gpu.subslice(indices, offset_start, offset_start + i32(pcmd.elem_count)))
             }
         }
         global_idx_offset += draw_list.idx_buffer.size

--- a/examples/third_party/dear_imgui/odin-imgui/imgui_impl_nogfx/imgui_impl_nogfx.odin
+++ b/examples/third_party/dear_imgui/odin-imgui/imgui_impl_nogfx/imgui_impl_nogfx.odin
@@ -148,12 +148,11 @@ render_draw_data :: proc(draw_data: ^im.Draw_Data, cmd_buf: gpu.Command_Buffer)
 
     // Prepare verts
     verts: gpu.slice_t(im.Draw_Vert)
-    indices: gpu.slice_t(u32)
-    colors: gpu.slice_t([4]f32)
+    indices: gpu.slice_t(u16)
     if draw_data.total_vtx_count > 0
     {
         verts   = gpu.arena_alloc(&fd.staging_arena, im.Draw_Vert, draw_data.total_vtx_count)
-        indices = gpu.arena_alloc(&fd.staging_arena, u32,          draw_data.total_idx_count)
+        indices = gpu.arena_alloc(&fd.staging_arena, u16,          draw_data.total_idx_count)
         dst_vert := 0
         dst_idx  := 0
         for i in 0..<draw_data.cmd_lists_count
@@ -162,16 +161,8 @@ render_draw_data :: proc(draw_data: ^im.Draw_Data, cmd_buf: gpu.Command_Buffer)
             idx_buffer_vec := ptr_to_multi_ptr(draw_list.idx_buffer.data)
             vtx_buffer_vec := ptr_to_multi_ptr(draw_list.vtx_buffer.data)
 
-            copy(verts.cpu[dst_vert:], vtx_buffer_vec[:draw_list.vtx_buffer.size])
-
-            // Convert indices from u16 to u32 as no_gfx only supports u32 for now.
-            for j in 0..<draw_list.idx_buffer.size
-            {
-                idx_u32 := u32(idx_buffer_vec[j])
-                assert(i64(idx_u32) < i64(draw_data.total_vtx_count))
-                indices.cpu[dst_idx + int(j)] = idx_u32
-            }
-
+            copy(verts.cpu[dst_vert:],  vtx_buffer_vec[:draw_list.vtx_buffer.size])
+            copy(indices.cpu[dst_idx:], idx_buffer_vec[:draw_list.idx_buffer.size])
             dst_vert += int(draw_list.vtx_buffer.size)
             dst_idx += int(draw_list.idx_buffer.size)
         }

--- a/examples/third_party/dear_imgui/odin-imgui/imgui_impl_nogfx/imgui_impl_nogfx.odin
+++ b/examples/third_party/dear_imgui/odin-imgui/imgui_impl_nogfx/imgui_impl_nogfx.odin
@@ -246,9 +246,9 @@ render_draw_data :: proc(draw_data: ^im.Draw_Data, cmd_buf: gpu.Command_Buffer)
                     tex_id = u32(im.draw_cmd_get_tex_id(pcmd)),
                     sampler_id = render_state.sampler_current_id,
                 }
-                indices_shifted := indices.gpu
-                indices_shifted.ptr = rawptr(uintptr(indices_shifted.ptr) + uintptr(pcmd.idx_offset + u32(global_idx_offset)) * 4)
-                gpu.cmd_draw_indexed_instanced(cmd_buf, vert_data, frag_data, indices_shifted, pcmd.elem_count)
+                indices_shifted := indices
+                indices_shifted = gpu.subslice(indices_shifted, pcmd.idx_offset)
+                gpu.cmd_draw_indexed(cmd_buf, vert_data, frag_data, gpu.subslice(indices_shifted, 0, pcmd.elem_count))
             }
         }
         global_idx_offset += draw_list.idx_buffer.size

--- a/gpu/gpu.odin
+++ b/gpu/gpu.odin
@@ -342,7 +342,7 @@ commands_begin: proc(queue: Queue, loc := #caller_location) -> Command_Buffer : 
 
 // Commands
 cmd_mem_copy_raw: proc(cmd_buf: Command_Buffer, dst, src: gpuptr, #any_int bytes: i64, loc := #caller_location) : _cmd_mem_copy_raw
-cmd_copy_to_texture: proc(cmd_buf: Command_Buffer, texture: Texture, src, dst: gpuptr, loc := #caller_location) : _cmd_copy_to_texture
+cmd_copy_to_texture: proc(cmd_buf: Command_Buffer, dst: Texture, src: gpuptr, loc := #caller_location) : _cmd_copy_to_texture
 cmd_copy_mips_to_texture: proc(cmd_buf: Command_Buffer, texture: Texture, src_buffer: gpuptr, regions: []Mip_Copy_Region, loc := #caller_location) : _cmd_copy_mips_to_texture
 cmd_blit_texture: proc(cmd_buf: Command_Buffer, src, dst: Texture, src_rects: []Blit_Rect, dst_rects: []Blit_Rect, filter: Filter, loc := #caller_location) : _cmd_blit_texture
 
@@ -378,8 +378,8 @@ cmd_draw_indexed_indirect_raw: proc(cmd_buf: Command_Buffer, vertex_data, fragme
 cmd_draw_indexed_indirect_multi_raw: proc(cmd_buf: Command_Buffer, vertex_data, fragment_data, indices: gpuptr,
                                           indirect_arguments: gpuptr, stride: u32, draw_count: gpuptr, loc := #caller_location) : _cmd_draw_indexed_indirect_multi_raw
 
-cmd_build_blas: proc(cmd_buf: Command_Buffer, bvh: BVH, bvh_storage, scratch_storage: gpuptr, shapes: []BVH_Shape, loc := #caller_location) : _cmd_build_blas
-cmd_build_tlas: proc(cmd_buf: Command_Buffer, bvh: BVH, bvh_storage, scratch_storage: gpuptr, instances: gpuptr, loc := #caller_location) : _cmd_build_tlas
+cmd_build_blas: proc(cmd_buf: Command_Buffer, bvh: BVH, scratch_storage: gpuptr, shapes: []BVH_Shape, loc := #caller_location) : _cmd_build_blas
+cmd_build_tlas: proc(cmd_buf: Command_Buffer, bvh: BVH, scratch_storage: gpuptr, instances: gpuptr, loc := #caller_location) : _cmd_build_tlas
 
 /////////////////////////
 // Userland Utilities

--- a/gpu/gpu.odin
+++ b/gpu/gpu.odin
@@ -60,6 +60,7 @@ Store_Op :: enum { Store = 0, Dont_Care, Resolve, Resolve_And_Store }
 Compare_Op :: enum { Never = 0, Less, Equal, Less_Equal, Greater, Not_Equal, Greater_Equal, Always }
 Blend_Op :: enum { Add, Subtract, Rev_Subtract, Min, Max }
 Blend_Factor :: enum { Zero, One, Src_Color, Dst_Color, Src_Alpha, Dst_Alpha, One_Minus_Src_Alpha, One_Minus_Src_Color, One_Minus_Dst_Alpha, One_Minus_Dst_Color }
+Index_Format :: enum { U32 = 0, U16 }
 Topology :: enum { Triangle_List = 0, Triangle_Strip, Triangle_Fan };
 Cull_Mode :: enum { Cull_CW = 0, Cull_CCW, None, All };
 Depth_Mode :: enum { Read = 0, Write }
@@ -368,7 +369,6 @@ cmd_set_blend_state: proc(cmd_buf: Command_Buffer, state: Blend_State, loc := #c
 cmd_set_viewport: proc(cmd_buf: Command_Buffer, viewport: Viewport, loc := #caller_location) : _cmd_set_viewport
 cmd_set_scissor: proc(cmd_buf: Command_Buffer, scissor: Rect_2D, loc := #caller_location) : _cmd_set_scissor
 
-// Run compute shader based on number of groups
 cmd_dispatch: proc(cmd_buf: Command_Buffer, compute_data: gpuptr, num_groups_x: u32, num_groups_y: u32 = 1, num_groups_z: u32 = 1, loc := #caller_location) : _cmd_dispatch
 
 // Schedule indirect compute shader based on number of groups, arguments is a pointer to a Dispatch_Indirect_Command struct
@@ -377,13 +377,13 @@ cmd_dispatch_indirect_raw: proc(cmd_buf: Command_Buffer, compute_data, arguments
 cmd_begin_render_pass: proc(cmd_buf: Command_Buffer, desc: Render_Pass_Desc, loc := #caller_location) : _cmd_begin_render_pass
 cmd_end_render_pass: proc(cmd_buf: Command_Buffer, loc := #caller_location) : _cmd_end_render_pass
 
-// Indices, vertex_data and fragment_data can be nil
+// Vertex_data and fragment_data can be nil if not used in the currently bound shader
 cmd_draw_indexed_raw: proc(cmd_buf: Command_Buffer, vertex_data, fragment_data, indices: gpuptr,
-                           index_count: u32, instance_count: u32 = 1, loc := #caller_location) : _cmd_draw_indexed_raw
-cmd_draw_indexed_indirect_raw: proc(cmd_buf: Command_Buffer, vertex_data, fragment_data, indices,
-                                    indirect_arguments: gpuptr, loc := #caller_location) : _cmd_draw_indexed_indirect_raw
+                           index_format: Index_Format, index_count: u32, instance_count: u32 = 1, loc := #caller_location) : _cmd_draw_indexed_raw
+cmd_draw_indexed_indirect_raw: proc(cmd_buf: Command_Buffer, vertex_data, fragment_data, indices: gpuptr,
+                                    index_format: Index_Format, indirect_arguments: gpuptr, loc := #caller_location) : _cmd_draw_indexed_indirect_raw
 cmd_draw_indexed_indirect_multi_raw: proc(cmd_buf: Command_Buffer, vertex_data, fragment_data, indices: gpuptr,
-                                          indirect_arguments: gpuptr, stride: u32, draw_count: gpuptr, loc := #caller_location) : _cmd_draw_indexed_indirect_multi_raw
+                                          index_format: Index_Format, indirect_arguments: gpuptr, stride: u32, draw_count: gpuptr, loc := #caller_location) : _cmd_draw_indexed_indirect_multi_raw
 
 cmd_build_blas: proc(cmd_buf: Command_Buffer, bvh: BVH, scratch_storage: gpuptr, shapes: []BVH_Shape, loc := #caller_location) : _cmd_build_blas
 cmd_build_tlas: proc(cmd_buf: Command_Buffer, bvh: BVH, scratch_storage: gpuptr, instances: gpuptr, loc := #caller_location) : _cmd_build_tlas
@@ -420,10 +420,12 @@ slice_to_ptr :: #force_inline proc(s: slice_t($T)) -> ptr_t(T)
 }
 
 // Type-safe variants of raw procedures
-cmd_draw_indexed :: #force_inline proc(cmd_buf: Command_Buffer, vertex_data, fragment_data: gpuptr, indices: slice_t(u32),
+cmd_draw_indexed :: #force_inline proc(cmd_buf: Command_Buffer, vertex_data, fragment_data: gpuptr, indices: slice_t($T),
                                        instance_count: u32 = 1, loc := #caller_location)
 {
-    cmd_draw_indexed_raw(cmd_buf, vertex_data, fragment_data, indices, u32(slice_len(indices)), instance_count, loc)
+    #assert(T == u32 || T == u16)
+    idx_fmt: Index_Format = .U32 when T == u32 else .U16
+    cmd_draw_indexed_raw(cmd_buf, vertex_data, fragment_data, indices, idx_fmt, u32(slice_len(indices)), instance_count, loc)
 }
 
 cmd_dispatch_indirect :: #force_inline proc(cmd_buf: Command_Buffer, compute_data: gpuptr,
@@ -432,16 +434,20 @@ cmd_dispatch_indirect :: #force_inline proc(cmd_buf: Command_Buffer, compute_dat
     cmd_dispatch_indirect_raw(cmd_buf, compute_data, arguments, loc)
 }
 
-cmd_draw_indexed_indirect :: #force_inline proc(cmd_buf: Command_Buffer, vertex_data, fragment_data, indices: gpuptr,
-                                                indirect_arguments: ptr_t($T), loc := #caller_location)
+cmd_draw_indexed_indirect :: #force_inline proc(cmd_buf: Command_Buffer, vertex_data, fragment_data: gpuptr, indices: slice_t($T),
+                                                indirect_arguments: ptr_t($T2), loc := #caller_location)
 {
-    cmd_draw_indexed_indirect_raw(cmd_buf, vertex_data, fragment_data, indices, indirect_arguments, loc)
+    #assert(T == u32 || T == u16)
+    idx_fmt: Index_Format = .U32 when T == u32 else .U16
+    cmd_draw_indexed_indirect_raw(cmd_buf, vertex_data, fragment_data, indices, idx_fmt, indirect_arguments, loc)
 }
 
-cmd_draw_indexed_indirect_multi :: #force_inline proc(cmd_buf: Command_Buffer, vertex_data, fragment_data, indices: gpuptr,
-                                                      indirect_arguments: slice_t($T), draw_count: ptr_t(u32), loc := #caller_location)
+cmd_draw_indexed_indirect_multi :: #force_inline proc(cmd_buf: Command_Buffer, vertex_data, fragment_data: gpuptr, indices: slice_t($T),
+                                                      indirect_arguments: slice_t($T2), draw_count: ptr_t(u32), loc := #caller_location)
 {
-    cmd_draw_indexed_indirect_multi_raw(cmd_buf, vertex_data, fragment_data, indices, indirect_arguments, size_of(T), draw_count, loc)
+    #assert(T == u32 || T == u16)
+    idx_fmt: Index_Format = .U32 when T == u32 else .U16
+    cmd_draw_indexed_indirect_multi_raw(cmd_buf, vertex_data, fragment_data, indices, idx_fmt, indirect_arguments, size_of(T2), draw_count, loc)
 }
 
 // Memory

--- a/gpu/gpu.odin
+++ b/gpu/gpu.odin
@@ -494,9 +494,9 @@ cmd_mem_copy_ptr :: #force_inline proc(cmd_buf: Command_Buffer, dst: ptr_t($T), 
     cmd_mem_copy_raw(cmd_buf, dst.gpu, src.gpu, size_of(T), loc = loc)
 }
 
-cmd_mem_copy_slice :: proc(cmd_buf: Command_Buffer, dst: slice_t($T), src: slice_t(T), #any_int count: i32, loc := #caller_location)
+cmd_mem_copy_slice :: proc(cmd_buf: Command_Buffer, dst: slice_t($T), src: slice_t(T), loc := #caller_location)
 {
-    cmd_mem_copy_raw(cmd_buf, dst.gpu, src.gpu, size_of(T) * count, loc = loc)
+    cmd_mem_copy_raw(cmd_buf, dst.gpu, src.gpu, size_of(T) * min(slice_len(dst), slice_len(src)), loc = loc)
 }
 
 cmd_mem_copy :: proc {

--- a/gpu/gpu.odin
+++ b/gpu/gpu.odin
@@ -95,19 +95,26 @@ Rect_2D :: struct
     size: [2]u32,
 }
 
+Rect_3D :: struct
+{
+    offset: [3]i32,
+    size: [3]u32,
+}
+
+Texture_Region :: struct
+{
+    rect: Rect_3D,     // rect.size == 0 -> entire size
+    mip_level: u32,
+    base_layer: u32,
+    layer_count: u32,  // 0 = 1
+}
+
 Blit_Rect :: struct
 {
     offset_a: [3]i32,  // offset_a == 0 && offset_b == 0 -> full image
     offset_b: [3]i32,  // offset_a == 0 && offset_b == 0 -> full image
     mip_level: u32,
     base_layer: u32,
-    layer_count: u32,
-}
-
-Mip_Copy_Region :: struct {
-    src_offset:  u64, // Offset in staging buffer
-    mip_level:   u32,
-    array_layer: u32,
     layer_count: u32,
 }
 
@@ -342,8 +349,8 @@ commands_begin: proc(queue: Queue, loc := #caller_location) -> Command_Buffer : 
 
 // Commands
 cmd_mem_copy_raw: proc(cmd_buf: Command_Buffer, dst, src: gpuptr, #any_int bytes: i64, loc := #caller_location) : _cmd_mem_copy_raw
-cmd_copy_to_texture: proc(cmd_buf: Command_Buffer, dst: Texture, src: gpuptr, loc := #caller_location) : _cmd_copy_to_texture
-cmd_copy_mips_to_texture: proc(cmd_buf: Command_Buffer, texture: Texture, src_buffer: gpuptr, regions: []Mip_Copy_Region, loc := #caller_location) : _cmd_copy_mips_to_texture
+cmd_copy_to_texture: proc(cmd_buf: Command_Buffer, dst: Texture, src: gpuptr, region: Texture_Region, loc := #caller_location) : _cmd_copy_to_texture
+// TODO: Missing cmd_copy_from_texture
 cmd_blit_texture: proc(cmd_buf: Command_Buffer, src, dst: Texture, src_rects: []Blit_Rect, dst_rects: []Blit_Rect, filter: Filter, loc := #caller_location) : _cmd_blit_texture
 
 cmd_set_desc_heap: proc(cmd_buf: Command_Buffer, textures, textures_rw, samplers, bvhs: gpuptr, loc := #caller_location) : _cmd_set_desc_heap

--- a/gpu/gpu.odin
+++ b/gpu/gpu.odin
@@ -371,18 +371,57 @@ cmd_begin_render_pass: proc(cmd_buf: Command_Buffer, desc: Render_Pass_Desc, loc
 cmd_end_render_pass: proc(cmd_buf: Command_Buffer, loc := #caller_location) : _cmd_end_render_pass
 
 // Indices, vertex_data and fragment_data can be nil
-cmd_draw_indexed_instanced: proc(cmd_buf: Command_Buffer, vertex_data, fragment_data, indices: gpuptr,
-                                 index_count: u32, instance_count: u32 = 1, loc := #caller_location) : _cmd_draw_indexed_instanced
-cmd_draw_indexed_instanced_indirect: proc(cmd_buf: Command_Buffer, vertex_data, fragment_data, indices,
-                                          indirect_arguments: gpuptr, loc := #caller_location) : _cmd_draw_indexed_instanced_indirect
-cmd_draw_indexed_instanced_indirect_multi: proc(cmd_buf: Command_Buffer, vertex_data, fragment_data, indices: gpuptr,
-                                                indirect_arguments: gpuptr, stride: u32, draw_count: gpuptr, loc := #caller_location) : _cmd_draw_indexed_instanced_indirect_multi
+cmd_draw_indexed_raw: proc(cmd_buf: Command_Buffer, vertex_data, fragment_data, indices: gpuptr,
+                           index_count: u32, instance_count: u32 = 1, loc := #caller_location) : _cmd_draw_indexed_raw
+cmd_draw_indexed_indirect_raw: proc(cmd_buf: Command_Buffer, vertex_data, fragment_data, indices,
+                                    indirect_arguments: gpuptr, loc := #caller_location) : _cmd_draw_indexed_indirect_raw
+cmd_draw_indexed_indirect_multi_raw: proc(cmd_buf: Command_Buffer, vertex_data, fragment_data, indices: gpuptr,
+                                          indirect_arguments: gpuptr, stride: u32, draw_count: gpuptr, loc := #caller_location) : _cmd_draw_indexed_instanced_indirect_multi_raw
 
 cmd_build_blas: proc(cmd_buf: Command_Buffer, bvh: BVH, bvh_storage, scratch_storage: gpuptr, shapes: []BVH_Shape, loc := #caller_location) : _cmd_build_blas
 cmd_build_tlas: proc(cmd_buf: Command_Buffer, bvh: BVH, bvh_storage, scratch_storage: gpuptr, instances: gpuptr, loc := #caller_location) : _cmd_build_tlas
 
 /////////////////////////
 // Userland Utilities
+
+// Slice
+// end == -1 means "until the end"
+subslice :: #force_inline proc(s: slice_t($T), #any_int start: i64, #any_int end: i64 = -1) -> slice_t(T)
+{
+    end_clean := end if end != -1 else i64(len(s.cpu))
+    assert(start >= 0)
+    assert(start < i64(len(s.cpu)))
+    assert(end_clean >= 0)
+    assert(end_clean <= i64(len(s.cpu)))
+    res := s
+    res.cpu = res.cpu[start:end_clean]
+    res.gpu.ptr = rawptr(uintptr(res.gpu.ptr) + uintptr(start * size_of(T)))
+    return res
+}
+
+slice_len :: #force_inline proc(s: slice_t($T)) -> i64
+{
+    return i64(len(s.cpu))
+}
+
+// Type-safe variants of raw procedures
+cmd_draw_indexed :: #force_inline proc(cmd_buf: Command_Buffer, vertex_data, fragment_data: gpuptr, indices: slice_t(u32),
+                                       instance_count: u32 = 1, loc := #caller_location)
+{
+    cmd_draw_indexed_raw(cmd_buf, vertex_data, fragment_data, indices, u32(slice_len(indices)), instance_count, loc)
+}
+
+cmd_draw_indexed_indirect :: proc(cmd_buf: Command_Buffer, vertex_data, fragment_data, indices,
+                                  indirect_arguments: gpuptr, loc := #caller_location)
+{
+    cmd_draw_indexed_indirect_raw(cmd_buf, vertex_data, fragment_data, indices, indirect_arguments, loc)
+}
+
+cmd_draw_indexed_indirect_multi :: proc(cmd_buf: Command_Buffer, vertex_data, fragment_data, indices: gpuptr,
+                                        indirect_arguments: gpuptr, stride: u32, draw_count: gpuptr, loc := #caller_location)
+{
+    cmd_draw_indexed_indirect_multi_raw(cmd_buf, vertex_data, fragment_data, indices, indirect_arguments, stride, draw_count, loc)
+}
 
 // Memory
 

--- a/gpu/gpu.odin
+++ b/gpu/gpu.odin
@@ -365,7 +365,7 @@ cmd_set_scissor: proc(cmd_buf: Command_Buffer, scissor: Rect_2D, loc := #caller_
 cmd_dispatch: proc(cmd_buf: Command_Buffer, compute_data: gpuptr, num_groups_x: u32, num_groups_y: u32 = 1, num_groups_z: u32 = 1, loc := #caller_location) : _cmd_dispatch
 
 // Schedule indirect compute shader based on number of groups, arguments is a pointer to a Dispatch_Indirect_Command struct
-cmd_dispatch_indirect: proc(cmd_buf: Command_Buffer, compute_data, arguments: gpuptr, loc := #caller_location) : _cmd_dispatch_indirect
+cmd_dispatch_indirect_raw: proc(cmd_buf: Command_Buffer, compute_data, arguments: gpuptr, loc := #caller_location) : _cmd_dispatch_indirect_raw
 
 cmd_begin_render_pass: proc(cmd_buf: Command_Buffer, desc: Render_Pass_Desc, loc := #caller_location) : _cmd_begin_render_pass
 cmd_end_render_pass: proc(cmd_buf: Command_Buffer, loc := #caller_location) : _cmd_end_render_pass
@@ -376,7 +376,7 @@ cmd_draw_indexed_raw: proc(cmd_buf: Command_Buffer, vertex_data, fragment_data, 
 cmd_draw_indexed_indirect_raw: proc(cmd_buf: Command_Buffer, vertex_data, fragment_data, indices,
                                     indirect_arguments: gpuptr, loc := #caller_location) : _cmd_draw_indexed_indirect_raw
 cmd_draw_indexed_indirect_multi_raw: proc(cmd_buf: Command_Buffer, vertex_data, fragment_data, indices: gpuptr,
-                                          indirect_arguments: gpuptr, stride: u32, draw_count: gpuptr, loc := #caller_location) : _cmd_draw_indexed_instanced_indirect_multi_raw
+                                          indirect_arguments: gpuptr, stride: u32, draw_count: gpuptr, loc := #caller_location) : _cmd_draw_indexed_indirect_multi_raw
 
 cmd_build_blas: proc(cmd_buf: Command_Buffer, bvh: BVH, bvh_storage, scratch_storage: gpuptr, shapes: []BVH_Shape, loc := #caller_location) : _cmd_build_blas
 cmd_build_tlas: proc(cmd_buf: Command_Buffer, bvh: BVH, bvh_storage, scratch_storage: gpuptr, instances: gpuptr, loc := #caller_location) : _cmd_build_tlas
@@ -404,6 +404,14 @@ slice_len :: #force_inline proc(s: slice_t($T)) -> i64
     return i64(len(s.cpu))
 }
 
+slice_to_ptr :: #force_inline proc(s: slice_t($T)) -> ptr_t(T)
+{
+    return {
+        cpu = raw_data(s.cpu),
+        gpu = s.gpu,
+    }
+}
+
 // Type-safe variants of raw procedures
 cmd_draw_indexed :: #force_inline proc(cmd_buf: Command_Buffer, vertex_data, fragment_data: gpuptr, indices: slice_t(u32),
                                        instance_count: u32 = 1, loc := #caller_location)
@@ -411,27 +419,25 @@ cmd_draw_indexed :: #force_inline proc(cmd_buf: Command_Buffer, vertex_data, fra
     cmd_draw_indexed_raw(cmd_buf, vertex_data, fragment_data, indices, u32(slice_len(indices)), instance_count, loc)
 }
 
-cmd_draw_indexed_indirect :: proc(cmd_buf: Command_Buffer, vertex_data, fragment_data, indices,
-                                  indirect_arguments: gpuptr, loc := #caller_location)
+cmd_dispatch_indirect :: #force_inline proc(cmd_buf: Command_Buffer, compute_data: gpuptr,
+                                            arguments: ptr_t(Dispatch_Indirect_Command), loc := #caller_location)
+{
+    cmd_dispatch_indirect_raw(cmd_buf, compute_data, arguments, loc)
+}
+
+cmd_draw_indexed_indirect :: #force_inline proc(cmd_buf: Command_Buffer, vertex_data, fragment_data, indices: gpuptr,
+                                                indirect_arguments: ptr_t($T), loc := #caller_location)
 {
     cmd_draw_indexed_indirect_raw(cmd_buf, vertex_data, fragment_data, indices, indirect_arguments, loc)
 }
 
-cmd_draw_indexed_indirect_multi :: proc(cmd_buf: Command_Buffer, vertex_data, fragment_data, indices: gpuptr,
-                                        indirect_arguments: gpuptr, stride: u32, draw_count: gpuptr, loc := #caller_location)
+cmd_draw_indexed_indirect_multi :: #force_inline proc(cmd_buf: Command_Buffer, vertex_data, fragment_data, indices: gpuptr,
+                                                      indirect_arguments: slice_t($T), draw_count: ptr_t(u32), loc := #caller_location)
 {
-    cmd_draw_indexed_indirect_multi_raw(cmd_buf, vertex_data, fragment_data, indices, indirect_arguments, stride, draw_count, loc)
+    cmd_draw_indexed_indirect_multi_raw(cmd_buf, vertex_data, fragment_data, indices, indirect_arguments, size_of(T), draw_count, loc)
 }
 
 // Memory
-
-ptr_apply_offset :: #force_inline proc(addr: ^ptr, #any_int offset: i64)
-{
-    if addr.cpu != nil {
-        addr.cpu = auto_cast(uintptr(addr.cpu) + uintptr(offset))
-    }
-    addr.gpu.ptr = auto_cast(uintptr(addr.gpu.ptr) + uintptr(offset))
-}
 
 ptr_t :: struct($T: typeid)
 {
@@ -774,8 +780,8 @@ Descriptor_Pool :: struct
 }
 
 // Using null descriptors most likely will result in a crash
-// and driver reset. The user can define global resources to
-// be used instead (e.g. a magenta texture).
+// and driver reset. Thus it's useful to be able to define global
+// default resources to be used instead (e.g. a magenta texture).
 desc_pool_create :: proc(#any_int texture_count: i64 = 65535,
                          #any_int texture_rw_count: i64 = 256,
                          #any_int sampler_count: i64 = 256,

--- a/gpu/impl_vk.odin
+++ b/gpu/impl_vk.odin
@@ -2084,29 +2084,28 @@ _cmd_mem_copy_raw :: proc(cmd_buf: Command_Buffer, dst, src: gpuptr, #any_int by
 }
 
 // TODO: dst is ignored atm.
-_cmd_copy_to_texture :: proc(cmd_buf: Command_Buffer, texture: Texture, src, dst: gpuptr, loc := #caller_location)
+_cmd_copy_to_texture :: proc(cmd_buf: Command_Buffer, dst: Texture, src: gpuptr, loc := #caller_location)
 {
     if ctx.validation
     {
         ok := true
         ok &= pool_check(&ctx.command_buffers, cmd_buf, "cmd_buf", loc)
         ok &= check_ptr(src, "src", loc)
-        ok &= check_ptr(dst, "dst", loc)
         if !ok do return
     }
 
     cmd_buf_info := pool_get(&ctx.command_buffers, cmd_buf)
-    tex_info := pool_get(&ctx.textures, texture.handle)
+    tex_info := pool_get(&ctx.textures, dst.handle)
     vk_image := tex_info.handle
 
     src_buf, src_offset, _ := get_buf_offset_from_gpu_ptr(src)
 
-    plane_aspect: vk.ImageAspectFlags = { .DEPTH } if texture.format == .D32_Float else { .COLOR }
+    plane_aspect: vk.ImageAspectFlags = { .DEPTH } if dst.format == .D32_Float else { .COLOR }
 
     vk.CmdCopyBufferToImage(cmd_buf_info.handle, src_buf, vk_image, .GENERAL, 1, &vk.BufferImageCopy {
         bufferOffset = vk.DeviceSize(src_offset),
-        bufferRowLength = texture.dimensions.x,
-        bufferImageHeight = texture.dimensions.y,
+        bufferRowLength = dst.dimensions.x,
+        bufferImageHeight = dst.dimensions.y,
         imageSubresource = {
             aspectMask = plane_aspect,
             mipLevel = 0,
@@ -2114,7 +2113,7 @@ _cmd_copy_to_texture :: proc(cmd_buf: Command_Buffer, texture: Texture, src, dst
             layerCount = 1,
         },
         imageOffset = {},
-        imageExtent = { texture.dimensions.x, texture.dimensions.y, texture.dimensions.z }
+        imageExtent = { dst.dimensions.x, dst.dimensions.y, dst.dimensions.z }
     })
 }
 
@@ -2863,7 +2862,7 @@ _cmd_draw_indexed_indirect_multi_raw :: proc(cmd_buf: Command_Buffer, vertex_dat
     vk.CmdDrawIndexedIndirectCount(vk_cmd_buf, arguments_buf, vk.DeviceSize(arguments_offset), draw_count_buf, vk.DeviceSize(draw_count_offset), max_draw_count, stride)
 }
 
-_cmd_build_blas :: proc(cmd_buf: Command_Buffer, bvh: BVH, bvh_storage, scratch_storage: gpuptr, shapes: []BVH_Shape, loc := #caller_location)
+_cmd_build_blas :: proc(cmd_buf: Command_Buffer, bvh: BVH, scratch_storage: gpuptr, shapes: []BVH_Shape, loc := #caller_location)
 {
     if ctx.validation
     {
@@ -2937,7 +2936,7 @@ _cmd_build_blas :: proc(cmd_buf: Command_Buffer, bvh: BVH, bvh_storage, scratch_
     vk.CmdBuildAccelerationStructuresKHR(vk_cmd_buf, 1, &build_info, &range_infos_ptr)
 }
 
-_cmd_build_tlas :: proc(cmd_buf: Command_Buffer, bvh: BVH, bvh_storage, scratch_storage, instances: gpuptr, loc := #caller_location)
+_cmd_build_tlas :: proc(cmd_buf: Command_Buffer, bvh: BVH, scratch_storage, instances: gpuptr, loc := #caller_location)
 {
     if ctx.validation
     {

--- a/gpu/impl_vk.odin
+++ b/gpu/impl_vk.odin
@@ -2705,7 +2705,7 @@ _cmd_end_render_pass :: proc(cmd_buf: Command_Buffer, loc := #caller_location)
 }
 
 _cmd_draw_indexed_raw :: proc(cmd_buf: Command_Buffer, vertex_data, fragment_data, indices: gpuptr,
-                          index_count: u32, instance_count: u32 = 1, loc := #caller_location)
+                              index_format: Index_Format, index_count: u32, instance_count: u32 = 1, loc := #caller_location)
 {
     if ctx.validation
     {
@@ -2733,11 +2733,11 @@ _cmd_draw_indexed_raw :: proc(cmd_buf: Command_Buffer, vertex_data, fragment_dat
     }
     vk.CmdPushConstants(vk_cmd_buf, ctx.common_pipeline_layout_graphics, { .VERTEX, .FRAGMENT }, 0, size_of(Graphics_Shader_Push_Constants), &push_constants)
 
-    vk.CmdBindIndexBuffer(vk_cmd_buf, indices_buf, vk.DeviceSize(indices_offset), .UINT32)
+    vk.CmdBindIndexBuffer(vk_cmd_buf, indices_buf, vk.DeviceSize(indices_offset), to_vk_index_format(index_format))
     vk.CmdDrawIndexed(vk_cmd_buf, index_count - (index_count % 3), instance_count, 0, 0, 0)
 }
 
-_cmd_draw_indexed_indirect_raw :: proc(cmd_buf: Command_Buffer, vertex_data, fragment_data, indices, indirect_arguments: gpuptr, loc := #caller_location)
+_cmd_draw_indexed_indirect_raw :: proc(cmd_buf: Command_Buffer, vertex_data, fragment_data, indices: gpuptr, index_format: Index_Format, indirect_arguments: gpuptr, loc := #caller_location)
 {
     if ctx.validation
     {
@@ -2763,12 +2763,12 @@ _cmd_draw_indexed_indirect_raw :: proc(cmd_buf: Command_Buffer, vertex_data, fra
     }
     vk.CmdPushConstants(vk_cmd_buf, ctx.common_pipeline_layout_graphics, { .VERTEX, .FRAGMENT }, 0, size_of(Graphics_Shader_Push_Constants), &push_constants)
 
-    vk.CmdBindIndexBuffer(vk_cmd_buf, indices_buf, vk.DeviceSize(indices_offset), .UINT32)
+    vk.CmdBindIndexBuffer(vk_cmd_buf, indices_buf, vk.DeviceSize(indices_offset), to_vk_index_format(index_format))
     vk.CmdDrawIndexedIndirect(vk_cmd_buf, arguments_buf, vk.DeviceSize(arguments_offset), 1, 0)
 }
 
 _cmd_draw_indexed_indirect_multi_raw :: proc(cmd_buf: Command_Buffer, vertex_data, fragment_data, indices: gpuptr,
-                                             indirect_arguments: gpuptr, stride: u32, draw_count: gpuptr, loc := #caller_location)
+                                             index_format: Index_Format, indirect_arguments: gpuptr, stride: u32, draw_count: gpuptr, loc := #caller_location)
 {
     if ctx.validation
     {
@@ -2800,7 +2800,7 @@ _cmd_draw_indexed_indirect_multi_raw :: proc(cmd_buf: Command_Buffer, vertex_dat
     }
     vk.CmdPushConstants(vk_cmd_buf, ctx.common_pipeline_layout_graphics, { .VERTEX, .FRAGMENT }, 0, size_of(Graphics_Shader_Push_Constants), &push_constants)
 
-    vk.CmdBindIndexBuffer(vk_cmd_buf, indices_buf, vk.DeviceSize(indices_offset), .UINT32)
+    vk.CmdBindIndexBuffer(vk_cmd_buf, indices_buf, vk.DeviceSize(indices_offset), to_vk_index_format(index_format))
 
     max_draw_count := max(u32)
     buf_size, ok_size := get_buf_size_from_gpu_ptr(indirect_arguments)

--- a/gpu/impl_vk.odin
+++ b/gpu/impl_vk.odin
@@ -2751,8 +2751,8 @@ _cmd_end_render_pass :: proc(cmd_buf: Command_Buffer, loc := #caller_location)
     vk.CmdEndRendering(vk_cmd_buf)
 }
 
-_cmd_draw_indexed_instanced :: proc(cmd_buf: Command_Buffer, vertex_data, fragment_data, indices: gpuptr,
-                                    index_count: u32, instance_count: u32 = 1, loc := #caller_location)
+_cmd_draw_indexed_raw :: proc(cmd_buf: Command_Buffer, vertex_data, fragment_data, indices: gpuptr,
+                          index_count: u32, instance_count: u32 = 1, loc := #caller_location)
 {
     if ctx.validation
     {
@@ -2761,6 +2761,9 @@ _cmd_draw_indexed_instanced :: proc(cmd_buf: Command_Buffer, vertex_data, fragme
         ok &= check_ptr_allow_nil(vertex_data, "vertex_data", loc)
         ok &= check_ptr_allow_nil(fragment_data, "fragment_data", loc)
         ok &= check_ptr_allow_nil(indices, "indices", loc)
+        if index_count % 3 != 0 {
+            log.errorf("'index_count' must be a multiple of 3.", location = loc)
+        }
         if !ok do return
     }
 
@@ -2778,10 +2781,10 @@ _cmd_draw_indexed_instanced :: proc(cmd_buf: Command_Buffer, vertex_data, fragme
     vk.CmdPushConstants(vk_cmd_buf, ctx.common_pipeline_layout_graphics, { .VERTEX, .FRAGMENT }, 0, size_of(Graphics_Shader_Push_Constants), &push_constants)
 
     vk.CmdBindIndexBuffer(vk_cmd_buf, indices_buf, vk.DeviceSize(indices_offset), .UINT32)
-    vk.CmdDrawIndexed(vk_cmd_buf, index_count, instance_count, 0, 0, 0)
+    vk.CmdDrawIndexed(vk_cmd_buf, index_count - (index_count % 3), instance_count, 0, 0, 0)
 }
 
-_cmd_draw_indexed_instanced_indirect :: proc(cmd_buf: Command_Buffer, vertex_data, fragment_data, indices, indirect_arguments: gpuptr, loc := #caller_location)
+_cmd_draw_indexed_indirect_raw :: proc(cmd_buf: Command_Buffer, vertex_data, fragment_data, indices, indirect_arguments: gpuptr, loc := #caller_location)
 {
     if ctx.validation
     {
@@ -2811,8 +2814,8 @@ _cmd_draw_indexed_instanced_indirect :: proc(cmd_buf: Command_Buffer, vertex_dat
     vk.CmdDrawIndexedIndirect(vk_cmd_buf, arguments_buf, vk.DeviceSize(arguments_offset), 1, 0)
 }
 
-_cmd_draw_indexed_instanced_indirect_multi :: proc(cmd_buf: Command_Buffer, vertex_data, fragment_data, indices: gpuptr,
-                                                   indirect_arguments: gpuptr, stride: u32, draw_count: gpuptr, loc := #caller_location)
+_cmd_draw_indexed_instanced_indirect_multi_raw :: proc(cmd_buf: Command_Buffer, vertex_data, fragment_data, indices: gpuptr,
+                                                       indirect_arguments: gpuptr, stride: u32, draw_count: gpuptr, loc := #caller_location)
 {
     if ctx.validation
     {

--- a/gpu/impl_vk.odin
+++ b/gpu/impl_vk.odin
@@ -1326,7 +1326,10 @@ _mem_suballoc :: proc(addr: ptr, offset, el_size, el_count: i64, loc := #caller_
     // TODO: Add suballocation to a suballocation list in allocs.
     // This lets us do bounds checking on arena allocated pointers for example.
     suballoc_p := addr
-    ptr_apply_offset(&suballoc_p, offset)
+    if suballoc_p.cpu != nil {
+        suballoc_p.cpu = auto_cast(uintptr(suballoc_p.cpu) + uintptr(offset))
+    }
+    suballoc_p.gpu.ptr = auto_cast(uintptr(suballoc_p.gpu.ptr) + uintptr(offset))
     return suballoc_p
 }
 
@@ -2584,7 +2587,7 @@ _cmd_dispatch :: proc(cmd_buf: Command_Buffer, compute_data: gpuptr, num_groups_
     vk.CmdDispatch(vk_cmd_buf, num_groups_x, num_groups_y, num_groups_z)
 }
 
-_cmd_dispatch_indirect :: proc(cmd_buf: Command_Buffer, compute_data, arguments: gpuptr, loc := #caller_location)
+_cmd_dispatch_indirect_raw :: proc(cmd_buf: Command_Buffer, compute_data, arguments: gpuptr, loc := #caller_location)
 {
     if ctx.validation
     {
@@ -2814,8 +2817,8 @@ _cmd_draw_indexed_indirect_raw :: proc(cmd_buf: Command_Buffer, vertex_data, fra
     vk.CmdDrawIndexedIndirect(vk_cmd_buf, arguments_buf, vk.DeviceSize(arguments_offset), 1, 0)
 }
 
-_cmd_draw_indexed_instanced_indirect_multi_raw :: proc(cmd_buf: Command_Buffer, vertex_data, fragment_data, indices: gpuptr,
-                                                       indirect_arguments: gpuptr, stride: u32, draw_count: gpuptr, loc := #caller_location)
+_cmd_draw_indexed_indirect_multi_raw :: proc(cmd_buf: Command_Buffer, vertex_data, fragment_data, indices: gpuptr,
+                                             indirect_arguments: gpuptr, stride: u32, draw_count: gpuptr, loc := #caller_location)
 {
     if ctx.validation
     {
@@ -2849,7 +2852,7 @@ _cmd_draw_indexed_instanced_indirect_multi_raw :: proc(cmd_buf: Command_Buffer, 
 
     vk.CmdBindIndexBuffer(vk_cmd_buf, indices_buf, vk.DeviceSize(indices_offset), .UINT32)
 
-    max_draw_count: u32 = 0xFFFFFFFF
+    max_draw_count := max(u32)
     buf_size, ok_size := get_buf_size_from_gpu_ptr(indirect_arguments)
     if ok_size && buf_size > vk.DeviceSize(arguments_offset)
     {

--- a/gpu/impl_vk.odin
+++ b/gpu/impl_vk.odin
@@ -2083,39 +2083,48 @@ _cmd_mem_copy_raw :: proc(cmd_buf: Command_Buffer, dst, src: gpuptr, #any_int by
     }
 }
 
-// TODO: dst is ignored atm.
-_cmd_copy_to_texture :: proc(cmd_buf: Command_Buffer, dst: Texture, src: gpuptr, loc := #caller_location)
+_cmd_copy_to_texture :: proc(cmd_buf: Command_Buffer, dst: Texture, src: gpuptr, region: Texture_Region = {}, loc := #caller_location)
 {
     if ctx.validation
     {
         ok := true
         ok &= pool_check(&ctx.command_buffers, cmd_buf, "cmd_buf", loc)
+        ok &= pool_check(&ctx.textures, dst.handle, "dst", loc)
         ok &= check_ptr(src, "src", loc)
         if !ok do return
     }
 
     cmd_buf_info := pool_get(&ctx.command_buffers, cmd_buf)
     tex_info := pool_get(&ctx.textures, dst.handle)
-    vk_image := tex_info.handle
 
-    src_buf, src_offset, _ := get_buf_offset_from_gpu_ptr(src)
+    src_buf, src_offset, ok_s := get_buf_offset_from_gpu_ptr(src)
+    assert(ok_s)
 
     plane_aspect: vk.ImageAspectFlags = { .DEPTH } if dst.format == .D32_Float else { .COLOR }
+    is_compressed := is_block_compressed(dst.format)
 
-    vk.CmdCopyBufferToImage(cmd_buf_info.handle, src_buf, vk_image, .GENERAL, 1, &vk.BufferImageCopy {
+    mip_width := max(1, dst.dimensions.x >> region.mip_level)
+    mip_height := max(1, dst.dimensions.y >> region.mip_level)
+    mip_depth := max(1, dst.dimensions.z >> region.mip_level)
+
+    copy := vk.BufferImageCopy{
         bufferOffset = vk.DeviceSize(src_offset),
-        bufferRowLength = dst.dimensions.x,
-        bufferImageHeight = dst.dimensions.y,
+        bufferRowLength = 0 if is_compressed else mip_width,
+        bufferImageHeight = 0 if is_compressed else mip_height,
         imageSubresource = {
             aspectMask = plane_aspect,
-            mipLevel = 0,
-            baseArrayLayer = 0,
-            layerCount = 1,
+            mipLevel = region.mip_level,
+            baseArrayLayer = region.base_layer,
+            layerCount = max(1, region.layer_count),
         },
         imageOffset = {},
-        imageExtent = { dst.dimensions.x, dst.dimensions.y, dst.dimensions.z }
-    })
+        imageExtent = { mip_width, mip_height, mip_depth },
+    }
+
+    vk.CmdCopyBufferToImage(cmd_buf_info.handle, src_buf, tex_info.handle, .GENERAL, 1, &copy)
 }
+
+// TODO: Missing: cmd_copy_from_texture
 
 _cmd_blit_texture :: proc(cmd_buf: Command_Buffer, src, dst: Texture, src_rects: []Blit_Rect, dst_rects: []Blit_Rect, filter: Filter, loc := #caller_location)
 {
@@ -2180,64 +2189,6 @@ _cmd_blit_texture :: proc(cmd_buf: Command_Buffer, src, dst: Texture, src_rects:
     }
 
     vk.CmdBlitImage(cmd_buf_info.handle, src_info.handle, .GENERAL, dst_info.handle, .GENERAL, u32(len(regions)), raw_data(regions), vk_filter)
-}
-
-_cmd_copy_mips_to_texture :: proc(cmd_buf: Command_Buffer, texture: Texture, src_buffer: gpuptr, regions: []Mip_Copy_Region, loc := #caller_location)
-{
-    if ctx.validation
-    {
-        ok := true
-        ok &= pool_check(&ctx.command_buffers, cmd_buf, "cmd_buf", loc)
-        ok &= pool_check(&ctx.textures, texture.handle, "texture", loc)
-        ok &= check_ptr(src_buffer, "src_buffer", loc)
-        if texture.mip_count < u32(len(regions)) {
-            log.error("'len(regions)' is greater than the available mip count.", location = loc)
-            ok = false
-        }
-        if !ok do return
-    }
-
-    cmd_buf_info := pool_get(&ctx.command_buffers, cmd_buf)
-    tex_info := pool_get(&ctx.textures, texture.handle)
-
-    src_buf, base_offset, ok_s := get_buf_offset_from_gpu_ptr(src_buffer)
-    assert(ok_s)
-
-    plane_aspect: vk.ImageAspectFlags = { .DEPTH } if texture.format == .D32_Float else { .COLOR }
-    is_compressed := is_block_compressed(texture.format)
-
-    scratch, _ := acquire_scratch()
-
-    copies := make([]vk.BufferImageCopy, len(regions), allocator = scratch)
-
-    for region, i in regions {
-        mip_width := max(1, texture.dimensions.x >> region.mip_level)
-        mip_height := max(1, texture.dimensions.y >> region.mip_level)
-        mip_depth := max(1, texture.dimensions.z >> region.mip_level)
-
-        copies[i] = vk.BufferImageCopy{
-            bufferOffset = vk.DeviceSize(u64(base_offset) + region.src_offset),
-            bufferRowLength = 0 if is_compressed else mip_width,
-            bufferImageHeight = 0 if is_compressed else mip_height,
-            imageSubresource = {
-                aspectMask = plane_aspect,
-                mipLevel = region.mip_level,
-                baseArrayLayer = region.array_layer,
-                layerCount = region.layer_count,
-            },
-            imageOffset = {},
-            imageExtent = { mip_width, mip_height, mip_depth },
-        }
-    }
-
-    vk.CmdCopyBufferToImage(
-        cmd_buf_info.handle,
-        src_buf,
-        tex_info.handle,
-        .GENERAL,
-        cast(u32) len(copies),
-        raw_data(copies),
-    )
 }
 
 _cmd_set_desc_heap :: proc(cmd_buf: Command_Buffer, textures, textures_rw, samplers, bvhs: gpuptr, loc := #caller_location)

--- a/gpu/impl_vk_type_conversion.odin
+++ b/gpu/impl_vk_type_conversion.odin
@@ -348,3 +348,13 @@ to_vk_cull_mode :: #force_inline proc(cull_mode: Cull_Mode) -> vk.CullModeFlags
     }
     return {}
 }
+
+to_vk_index_format :: #force_inline proc(index_format: Index_Format) -> vk.IndexType
+{
+    switch index_format
+    {
+        case .U32: return .UINT32
+        case .U16: return .UINT16
+    }
+    return {}
+}

--- a/readme.md
+++ b/readme.md
@@ -46,7 +46,7 @@ defer {
 
 // --- Issue copy commands to GPU local memory
 upload_cmd_buf := gpu.commands_begin(.Main)
-gpu.cmd_mem_copy(upload_cmd_buf, verts_local, verts, len(verts.cpu))
+gpu.cmd_mem_copy(upload_cmd_buf, verts_local, verts)
 // ...
 gpu.cmd_barrier(upload_cmd_buf, .Transfer, .All, {})
 gpu.queue_submit(.Main, { upload_cmd_buf })
@@ -91,7 +91,7 @@ for true
     verts_data.cpu.verts = verts_local.gpu.ptr
 
     // Just pass pointers to your data!
-    gpu.cmd_draw_indexed_instanced(cmd_buf, verts_data, {}, indices_local, 3, 1)
+    gpu.cmd_draw_indexed(cmd_buf, verts_data, {}, indices_local)
     gpu.cmd_end_render_pass(cmd_buf)
     gpu.queue_submit(.Main, { cmd_buf }, frame_sem, next_frame)
 


### PR DESCRIPTION
Cleaning up a few inconsistencies with procedures that involve slices. Added type-safe versions of some procedures. For example cmd_draw_indexed now takes in a slice_t(u32) for indices, making it so you can't mistakenly pass vertices in place of indices leading to a hard to debug crash. Removed count argument from cmd_mem_copy as that is already encoded in the slices themselves. Added slice_t utils to mirror Odin's slice operators/utils. Also general API cleanup.