### PR TITLE
make linux use libstdc++ instead of libc++

### DIFF
--- a/gpu/vma/vma.odin
+++ b/gpu/vma/vma.odin
@@ -1,7 +1,12 @@
 package vma
 
-when ODIN_OS == .Linux || ODIN_OS == .Darwin {
-	@(require, extra_linker_flags="-lstdc++") foreign import stdcpp "system:c++"
+when ODIN_OS == .Linux {
+	@(require, extra_linker_flags = "-lstdc++")
+	foreign import stdcpp "system:stdc++"
+}
+when ODIN_OS == .Darwin {
+	@(require, extra_linker_flags = "-lstdc++")
+	foreign import stdcpp "system:c++"
 }
 
 when ODIN_OS == .Windows {


### PR DESCRIPTION
libc++ is the clang-specific implementation that afaik exists so apple can avoid the GPL and usually isn't the norm on linux 
and even clang itself instead links against libstdc++ on linux (at least on my machine)
I don't even have libc++ installed on my system despite having compiled a bunch of c++ on it by now
libstdc++ will be preinstalled on basically any linux system