### PR TITLE
Add a way to wrap externally owned VkImages

### DIFF
--- a/gpu/impl_vk.odin
+++ b/gpu/impl_vk.odin
@@ -3662,23 +3662,6 @@ _vk_wrap_image :: proc(image: vk.Image, desc: Texture_Desc, name := "", loc := #
     }
 }
 
-_vk_unwrap_image :: proc(texture: Texture, loc := #caller_location)
-{
-    if ctx.validation
-    {
-        ok := true
-        ok &= pool_check(&ctx.textures, texture.handle, "texture", loc)
-        if !ok do return
-    }
-
-    tex_info := pool_get(&ctx.textures, texture.handle)
-    for view in tex_info.views {
-        vk.DestroyImageView(ctx.device, view.view, nil)
-    }
-    delete(tex_info.views)
-    pool_remove(&ctx.textures, texture.handle)
-}
-
 @(thread_local) EXTRA_OPT_DEVICE_EXTENSIONS: [dynamic]cstring
 _vk_add_opt_device_extension :: proc(extension: cstring)
 {

--- a/gpu/impl_vk.odin
+++ b/gpu/impl_vk.odin
@@ -130,7 +130,8 @@ Alloc_Impl_Info :: struct
 Texture_Info :: struct
 {
     handle: vk.Image,
-    views: [dynamic]Image_View_Info
+    views: [dynamic]Image_View_Info,
+    owns_image: bool,
 }
 
 @(private="file")
@@ -1470,7 +1471,7 @@ _texture_create :: proc(desc: Texture_Desc, storage: gpuptr, queue: Queue = .Mai
 
     vk_set_debug_name(name, u64(image), .IMAGE)
 
-    tex_info := Texture_Info { image, {} }
+    tex_info := Texture_Info { handle = image, owns_image = true }
     sync.guard(&ctx.lock)
     return Texture {
         dimensions = desc_clean.dimensions,
@@ -1499,7 +1500,9 @@ _texture_destroy :: proc(texture: Texture, loc := #caller_location)
     delete(tex_info.views)
     tex_info.views = {}
 
-    vk.DestroyImage(ctx.device, vk_image, nil)
+    if tex_info.owns_image {
+        vk.DestroyImage(ctx.device, vk_image, nil)
+    }
     pool_remove(&ctx.textures, texture.handle)
 }
 
@@ -3634,6 +3637,46 @@ _vk_get_buffer :: proc(addr: gpuptr) -> (vk.Buffer, u32)
     buf, offset, ok := get_buf_offset_from_gpu_ptr(addr)
     ensure(ok)
     return buf, offset
+}
+
+_vk_wrap_image :: proc(image: vk.Image, desc: Texture_Desc, name := "", loc := #caller_location) -> Texture
+{
+    desc_clean := texture_desc_cleanup(desc)
+
+    if ctx.validation {
+        ensure(image != {}, "Cannot wrap a nil VkImage.")
+    }
+
+    tex_info := Texture_Info {
+        handle = image,
+        owns_image = false,
+    }
+
+    sync.guard(&ctx.lock)
+    return Texture {
+        dimensions = desc_clean.dimensions,
+        format = desc_clean.format,
+        mip_count = desc_clean.mip_count,
+        sample_count = desc_clean.sample_count,
+        handle = pool_add(&ctx.textures, tex_info, { name = name, created_at = loc }),
+    }
+}
+
+_vk_unwrap_image :: proc(texture: Texture, loc := #caller_location)
+{
+    if ctx.validation
+    {
+        ok := true
+        ok &= pool_check(&ctx.textures, texture.handle, "texture", loc)
+        if !ok do return
+    }
+
+    tex_info := pool_get(&ctx.textures, texture.handle)
+    for view in tex_info.views {
+        vk.DestroyImageView(ctx.device, view.view, nil)
+    }
+    delete(tex_info.views)
+    pool_remove(&ctx.textures, texture.handle)
 }
 
 @(thread_local) EXTRA_OPT_DEVICE_EXTENSIONS: [dynamic]cstring

--- a/gpu/interop.odin
+++ b/gpu/interop.odin
@@ -20,7 +20,6 @@ vk_add_device_extension: proc(extension: cstring) : _vk_add_device_extension
 // Wraps an externally owned VkImage, e.g. an OpenXR swapchain image, as a no_gfx texture.
 // no_gfx owns image views it creates for the wrapper, but it does not destroy the VkImage.
 vk_wrap_image: proc(image: vk.Image, desc: Texture_Desc, name := "", loc := #caller_location) -> Texture : _vk_wrap_image
-vk_unwrap_image: proc(texture: Texture, loc := #caller_location) : _vk_unwrap_image
 
 // NOTE: vk_move_* type procedures move ownership to no_gfx, handles MUST ONLY be destroyed on the no_gfx side.
 vk_move_semaphore: proc(semaphore: vk.Semaphore, loc := #caller_location) -> Semaphore : _vk_move_semaphore

--- a/gpu/interop.odin
+++ b/gpu/interop.odin
@@ -17,5 +17,10 @@ vk_get_buffer: proc(addr: gpuptr) -> (vk.Buffer, u32) : _vk_get_buffer
 vk_add_opt_device_extension: proc(extension: cstring) : _vk_add_opt_device_extension
 vk_add_device_extension: proc(extension: cstring) : _vk_add_device_extension
 
+// Wraps an externally owned VkImage, e.g. an OpenXR swapchain image, as a no_gfx texture.
+// no_gfx owns image views it creates for the wrapper, but it does not destroy the VkImage.
+vk_wrap_image: proc(image: vk.Image, desc: Texture_Desc, name := "", loc := #caller_location) -> Texture : _vk_wrap_image
+vk_unwrap_image: proc(texture: Texture, loc := #caller_location) : _vk_unwrap_image
+
 // NOTE: vk_move_* type procedures move ownership to no_gfx, handles MUST ONLY be destroyed on the no_gfx side.
 vk_move_semaphore: proc(semaphore: vk.Semaphore, loc := #caller_location) -> Semaphore : _vk_move_semaphore


### PR DESCRIPTION
This is required for letting no_gfx manage swapchains created in other APIs, such as swapchains returned from OpenXR or OpenVR. We let no_gfx own the image views it created for wrapped VkImages, but we disallow it from destroying the VkImage.

* Added APIs: vk_wrap_image, vk_unwrap_image
* Changed/removed APIs: none