### PR TITLE
Map layer counts to layer attachments

### DIFF
--- a/gpu/impl_common.odin
+++ b/gpu/impl_common.odin
@@ -304,3 +304,11 @@ texture_desc_cleanup :: #force_inline proc(desc: Texture_Desc) -> Texture_Desc
     res.sample_count = max(1, res.sample_count)
     return res
 }
+
+texture_view_desc_cleanup :: #force_inline proc(desc: Texture_View_Desc) -> Texture_View_Desc
+{
+    res := desc
+    res.mip_count = max(1, res.mip_count)
+    res.layer_count = max(1, res.layer_count)
+    return res
+}

--- a/gpu/impl_vk.odin
+++ b/gpu/impl_vk.odin
@@ -3280,7 +3280,7 @@ create_swapchain :: proc(width: u32, height: u32, frames_in_flight: u32) -> Swap
         imageColorSpace = surface_format.colorSpace,
         imageExtent = { res.width, res.height },
         imageArrayLayers = 1,
-        imageUsage = { .COLOR_ATTACHMENT },
+        imageUsage = { .COLOR_ATTACHMENT, .TRANSFER_SRC, .TRANSFER_DST  },
         preTransform = surface_caps.currentTransform,
         compositeAlpha = { .OPAQUE },
         presentMode = present_mode,
@@ -3708,7 +3708,8 @@ to_vk_render_attachment :: #force_inline proc(attach: Render_Attachment) -> vk.R
             subresourceRange = {
                 aspectMask = plane_aspect,
                 levelCount = 1,
-                layerCount = 1,
+                baseArrayLayer = u32(view_desc.base_layer),
+                layerCount = u32(view_desc.layer_count) if view_desc.layer_count > 0 else 1,
             }
         }
         view = get_or_add_image_view(texture.handle, image_view_ci)
@@ -3725,7 +3726,8 @@ to_vk_render_attachment :: #force_inline proc(attach: Render_Attachment) -> vk.R
             subresourceRange = {
                 aspectMask = plane_aspect,
                 levelCount = 1,
-                layerCount = 1,
+                baseArrayLayer = u32(resolve_view_desc.base_layer),
+                layerCount = u32(resolve_view_desc.layer_count) if resolve_view_desc.layer_count > 0 else 1,
             }
         }
         resolve_view = get_or_add_image_view(resolve_texture.handle, resolve_image_view_ci)

--- a/gpu/impl_vk.odin
+++ b/gpu/impl_vk.odin
@@ -3680,10 +3680,10 @@ _vk_move_semaphore :: proc(semaphore: vk.Semaphore, loc := #caller_location) -> 
 @(private)
 to_vk_render_attachment :: #force_inline proc(attach: Render_Attachment) -> vk.RenderingAttachmentInfo
 {
-    view_desc := attach.view
+    view_desc := texture_view_desc_cleanup(attach.view)
     texture := attach.texture
     resolve_texture := attach.resolve_texture
-    resolve_view_desc := attach.resolve_view
+    resolve_view_desc := texture_view_desc_cleanup(attach.resolve_view)
 
     has_output := texture != {}
     vk_image := pool_get(&ctx.textures, texture.handle).handle if has_output else vk.Image(0)
@@ -3709,7 +3709,7 @@ to_vk_render_attachment :: #force_inline proc(attach: Render_Attachment) -> vk.R
                 aspectMask = plane_aspect,
                 levelCount = 1,
                 baseArrayLayer = u32(view_desc.base_layer),
-                layerCount = u32(view_desc.layer_count) if view_desc.layer_count > 0 else 1,
+                layerCount = u32(view_desc.layer_count),
             }
         }
         view = get_or_add_image_view(texture.handle, image_view_ci)
@@ -3727,7 +3727,7 @@ to_vk_render_attachment :: #force_inline proc(attach: Render_Attachment) -> vk.R
                 aspectMask = plane_aspect,
                 levelCount = 1,
                 baseArrayLayer = u32(resolve_view_desc.base_layer),
-                layerCount = u32(resolve_view_desc.layer_count) if resolve_view_desc.layer_count > 0 else 1,
+                layerCount = u32(resolve_view_desc.layer_count),
             }
         }
         resolve_view = get_or_add_image_view(resolve_texture.handle, resolve_image_view_ci)


### PR DESCRIPTION
* make sure layer_count and base_layer are applied to render attachments (needed for stereoscopic rendering)
* add TRANSFER_SRC and TRANSFER_DST to the default swapchain as swapchain readback is needed for many VR and regular desktop apps (should be supported on basically every gpu, so this shouldn't hurt anybody)