### PR TITLE
fix(gpu/vk): set default color blend equation to pass validation

### DIFF
--- a/gpu/impl_vk.odin
+++ b/gpu/impl_vk.odin
@@ -2882,6 +2882,14 @@ _cmd_begin_render_pass :: proc(cmd_buf: Command_Buffer, desc: Render_Pass_Desc, 
     }
     vk.CmdSetScissorWithCount(vk_cmd_buf, 1, &scissor)
     vk.CmdSetRasterizerDiscardEnable(vk_cmd_buf, false)
+    vk.CmdSetColorBlendEquationEXT(vk_cmd_buf, 0, 1, &vk.ColorBlendEquationEXT {
+        srcColorBlendFactor = .SRC_ALPHA,
+        dstColorBlendFactor = .ONE_MINUS_SRC_ALPHA,
+        colorBlendOp        = .ADD,
+        srcAlphaBlendFactor = .ONE,
+        dstAlphaBlendFactor = .ONE_MINUS_SRC_ALPHA,
+        alphaBlendOp        = .ADD,
+    })
 
     // Unused
     vk.CmdSetVertexInputEXT(vk_cmd_buf, 0, nil, 0, nil)


### PR DESCRIPTION
This PR fixes a validation layer error (VUID-vkCmdDrawIndexed-rasterizerDiscardEnable-09418) where the dynamic color blend equation state was left uninitialized prior to drawing.

Prior to the fix, running any of the example programs with validation enabled would result in this validation error being logged to the console every frame
```
[ERROR] --- [2026-06-10 03:01:15]
[impl_vk.odin:3228:vk_debug_callback()]

Validation Error: [ VUID-vkCmdDrawIndexed-rasterizerDiscardEnable-09418 ]

Object 0: handle = 0x3831afc0, type = VK_OBJECT_TYPE_COMMAND_BUFFER; | MessageID = 0x305b1acf | vkCmdDrawIndexed():  
VK_DYNAMIC_STATE_COLOR_BLEND_EQUATION_EXT state not set for this command buffer. 

The Vulkan spec states: If a shader object is bound to the VK_SHADER_STAGE_FRAGMENT_BIT stage, and the most recent call to vkCmdSetRasterizerDiscardEnable in the current command buffer set rasterizerDiscardEnable to VK_FALSE, then vkCmdSetColorBlendEquationEXT must have been called in the current command buffer prior to this drawing command, and the attachments specified by the firstAttachment and attachmentCount parameters of vkCmdSetColorBlendEquationEXT calls must specify the blend equations for all active color attachments in the current subpass where blending is enabled (https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#VUID-vkCmdDrawIndexed-rasterizerDiscardEnable-09418)
```

Since The Vulkan backend utilizes dynamic states, the Vulkan specification strictly requires that the color blend equation state be explicitly bound to the command buffer prior to any drawing commands if rasterizer discard is disabled.

This change initializes a default alpha blending equation during `_cmd_begin_render_pass`.

I successfully ran all of the examples after the change to verify that they all exhibit the same behavior.

Note: This fix defaults the blend equation to standard non-premultiplied alpha blending (SRC_ALPHA / ONE_MINUS_SRC_ALPHA). But if the intention of this library is to have blending disabled by default then it might be a good idea to ensure vk.CmdSetColorBlendEnableEXT is being explicitly set to false somewhere in this initialization sequence to prevent unexpected blending behaviors on background clear colors.