### PR TITLE
Making no_gfx_api MoltenVK Compatible

### DIFF
--- a/examples/1_triangle/main.odin
+++ b/examples/1_triangle/main.odin
@@ -19,6 +19,14 @@ main :: proc()
     ok_i := sdl.Init({ .VIDEO })
     assert(ok_i)
 
+    when ODIN_OS == .Darwin 
+    {
+        if (!sdl.Vulkan_LoadLibrary("libvulkan.1.dylib"))
+        {
+            panic("Unable to load vulkan library!")
+        }
+    }
+
     console_logger := log.create_console_logger()
     defer log.destroy_console_logger(console_logger)
     context.logger = console_logger

--- a/examples/1_triangle/main.odin
+++ b/examples/1_triangle/main.odin
@@ -7,6 +7,8 @@ import "core:math/linalg"
 
 import "../../gpu"
 
+import shared "../shared"
+
 import sdl "vendor:sdl3"
 
 Start_Window_Size_X :: 1000
@@ -16,16 +18,7 @@ Example_Name :: "Triangle"
 
 main :: proc()
 {
-    ok_i := sdl.Init({ .VIDEO })
-    assert(ok_i)
-
-    when ODIN_OS == .Darwin 
-    {
-        if (!sdl.Vulkan_LoadLibrary("libvulkan.1.dylib"))
-        {
-            panic("Unable to load vulkan library!")
-        }
-    }
+    shared.sdl_init()
 
     console_logger := log.create_console_logger()
     defer log.destroy_console_logger(console_logger)

--- a/examples/2_textures/main.odin
+++ b/examples/2_textures/main.odin
@@ -26,6 +26,14 @@ main :: proc()
     ok_i := sdl.Init({ .VIDEO })
     assert(ok_i)
 
+    when ODIN_OS == .Darwin 
+    {
+        if (!sdl.Vulkan_LoadLibrary("libvulkan.1.dylib"))
+        {
+            panic("Unable to load vulkan library!")
+        }
+    }
+    
     console_logger := log.create_console_logger()
     defer log.destroy_console_logger(console_logger)
     context.logger = console_logger

--- a/examples/2_textures/main.odin
+++ b/examples/2_textures/main.odin
@@ -11,6 +11,8 @@ import "core:math"
 
 import "../../gpu"
 
+import shared "../shared"
+
 import sdl "vendor:sdl3"
 
 Start_Window_Size_X :: 1000
@@ -23,16 +25,7 @@ Bowser_Texture :: #load("textures/bowser.png")
 
 main :: proc()
 {
-    ok_i := sdl.Init({ .VIDEO })
-    assert(ok_i)
-
-    when ODIN_OS == .Darwin 
-    {
-        if (!sdl.Vulkan_LoadLibrary("libvulkan.1.dylib"))
-        {
-            panic("Unable to load vulkan library!")
-        }
-    }
+    shared.sdl_init()
     
     console_logger := log.create_console_logger()
     defer log.destroy_console_logger(console_logger)

--- a/examples/3_3D/main.odin
+++ b/examples/3_3D/main.odin
@@ -29,6 +29,14 @@ main :: proc()
     ok_i := sdl.Init({ .VIDEO })
     assert(ok_i)
 
+    when ODIN_OS == .Darwin 
+    {
+        if (!sdl.Vulkan_LoadLibrary("libvulkan.1.dylib"))
+        {
+            panic("Unable to load vulkan library!")
+        }
+    }
+
     console_logger := log.create_console_logger()
     defer log.destroy_console_logger(console_logger)
     context.logger = console_logger
@@ -44,8 +52,10 @@ main :: proc()
     window := sdl.CreateWindow(Example_Name, Start_Window_Size_X, Start_Window_Size_Y, window_flags)
     ensure(window != nil)
 
-    window_size_x := i32(Start_Window_Size_X)
-    window_size_y := i32(Start_Window_Size_Y)
+    display_scale: f32 = sdl.GetWindowDisplayScale(window)
+
+    window_size_x := i32(Start_Window_Size_X * display_scale)
+    window_size_y := i32(Start_Window_Size_Y * display_scale)
 
     ok := gpu.init()
     ensure(ok)
@@ -105,7 +115,7 @@ main :: proc()
 
         old_window_size_x := window_size_x
         old_window_size_y := window_size_y
-        sdl.GetWindowSize(window, &window_size_x, &window_size_y)
+        sdl.GetWindowSizeInPixels(window, &window_size_x, &window_size_y)
         if .MINIMIZED in sdl.GetWindowFlags(window) || window_size_x <= 0 || window_size_y <= 0
         {
             sdl.Delay(16)

--- a/examples/3_3D/main.odin
+++ b/examples/3_3D/main.odin
@@ -26,16 +26,7 @@ main :: proc()
 	shared.CAM_ANGLE = {1.570796, 0.3665192}
     fmt.println("Right-click + WASD for first-person controls.")
 
-    ok_i := sdl.Init({ .VIDEO })
-    assert(ok_i)
-
-    when ODIN_OS == .Darwin 
-    {
-        if (!sdl.Vulkan_LoadLibrary("libvulkan.1.dylib"))
-        {
-            panic("Unable to load vulkan library!")
-        }
-    }
+    shared.sdl_init()
 
     console_logger := log.create_console_logger()
     defer log.destroy_console_logger(console_logger)

--- a/examples/4_textures_advanced/main.odin
+++ b/examples/4_textures_advanced/main.odin
@@ -30,6 +30,14 @@ main :: proc()
     ok_i := sdl.Init({ .VIDEO })
     assert(ok_i)
 
+    when ODIN_OS == .Darwin 
+    {
+        if (!sdl.Vulkan_LoadLibrary("libvulkan.1.dylib"))
+        {
+            panic("Unable to load vulkan library!")
+        }
+    }
+
     console_logger := log.create_console_logger()
     defer log.destroy_console_logger(console_logger)
     context.logger = console_logger
@@ -45,8 +53,10 @@ main :: proc()
     window := sdl.CreateWindow(Example_Name, Start_Window_Size_X, Start_Window_Size_Y, window_flags)
     ensure(window != nil)
 
-    window_size_x := i32(Start_Window_Size_X)
-    window_size_y := i32(Start_Window_Size_Y)
+    display_scale: f32 = sdl.GetWindowDisplayScale(window)
+
+    window_size_x := i32(Start_Window_Size_X * display_scale)
+    window_size_y := i32(Start_Window_Size_Y * display_scale)
 
     ok := gpu.init()
     ensure(ok)
@@ -124,7 +134,7 @@ main :: proc()
 
         old_window_size_x := window_size_x
         old_window_size_y := window_size_y
-        sdl.GetWindowSize(window, &window_size_x, &window_size_y)
+        sdl.GetWindowSizeInPixels(window, &window_size_x, &window_size_y)
         if .MINIMIZED in sdl.GetWindowFlags(window) || window_size_x <= 0 || window_size_y <= 0
         {
             sdl.Delay(16)

--- a/examples/4_textures_advanced/main.odin
+++ b/examples/4_textures_advanced/main.odin
@@ -27,16 +27,7 @@ main :: proc()
     shared.CAM_ANGLE = {math.PI * 0.25, math.PI * 0.25}
     fmt.println("Right-click + WASD for first-person controls.")
 
-    ok_i := sdl.Init({ .VIDEO })
-    assert(ok_i)
-
-    when ODIN_OS == .Darwin 
-    {
-        if (!sdl.Vulkan_LoadLibrary("libvulkan.1.dylib"))
-        {
-            panic("Unable to load vulkan library!")
-        }
-    }
+    shared.sdl_init()
 
     console_logger := log.create_console_logger()
     defer log.destroy_console_logger(console_logger)

--- a/examples/5_indirect_triangles/main.odin
+++ b/examples/5_indirect_triangles/main.odin
@@ -7,6 +7,8 @@ import "core:math/linalg"
 
 import "../../gpu"
 
+import shared "../shared"
+
 import sdl "vendor:sdl3"
 
 Start_Window_Size_X :: 1000
@@ -19,8 +21,7 @@ Use_Indirect_Multi :: true
 
 main :: proc()
 {
-    ok_i := sdl.Init({ .VIDEO })
-    assert(ok_i)
+    shared.sdl_init()
 
     console_logger := log.create_console_logger()
     defer log.destroy_console_logger(console_logger)
@@ -37,8 +38,10 @@ main :: proc()
     window := sdl.CreateWindow(Example_Name, Start_Window_Size_X, Start_Window_Size_Y, window_flags)
     ensure(window != nil)
 
-    window_size_x := i32(Start_Window_Size_X)
-    window_size_y := i32(Start_Window_Size_Y)
+    display_scale: f32 = sdl.GetWindowDisplayScale(window)
+
+    window_size_x := i32(Start_Window_Size_X * display_scale)
+    window_size_y := i32(Start_Window_Size_Y * display_scale)
 
     ok := gpu.init()
     ensure(ok)
@@ -151,7 +154,7 @@ main :: proc()
 
         old_window_size_x := window_size_x
         old_window_size_y := window_size_y
-        sdl.GetWindowSize(window, &window_size_x, &window_size_y)
+        sdl.GetWindowSizeInPixels(window, &window_size_x, &window_size_y)
         if .MINIMIZED in sdl.GetWindowFlags(window) || window_size_x <= 0 || window_size_y <= 0
         {
             sdl.Delay(16)
@@ -199,7 +202,7 @@ main :: proc()
             gpu.cmd_draw_indexed_indirect_multi(cmd_buf, shared_vert_data, {}, indices_local, indirect_data_local, count_local)
         } else {
             // Renders only the first draw from the indirect data buffer
-            gpu.cmd_draw_indexed_indirect(cmd_buf, shared_vert_data, {}, indices_local, indirect_data_local)
+            gpu.cmd_draw_indexed_indirect(cmd_buf, shared_vert_data, {}, indices_local, gpu.slice_to_ptr(indirect_data_local))
         }
 
         gpu.cmd_end_render_pass(cmd_buf)

--- a/examples/5_indirect_triangles/main.odin
+++ b/examples/5_indirect_triangles/main.odin
@@ -21,7 +21,7 @@ Use_Indirect_Multi :: true
 
 main :: proc()
 {
-    shared.sdl_init()
+    shared.sdl_init(moltenvk_working_status = .Partially_Works)
 
     console_logger := log.create_console_logger()
     defer log.destroy_console_logger(console_logger)

--- a/examples/6_compute_shaders/main.odin
+++ b/examples/6_compute_shaders/main.odin
@@ -25,6 +25,14 @@ main :: proc()
     ok_i := sdl.Init({ .VIDEO })
     assert(ok_i)
 
+    when ODIN_OS == .Darwin 
+    {
+        if (!sdl.Vulkan_LoadLibrary("libvulkan.1.dylib"))
+        {
+            panic("Unable to load vulkan library!")
+        }
+    }
+
     console_logger := log.create_console_logger()
     defer log.destroy_console_logger(console_logger)
     context.logger = console_logger
@@ -40,8 +48,10 @@ main :: proc()
     window := sdl.CreateWindow(Example_Name, Start_Window_Size_X, Start_Window_Size_Y, window_flags)
     ensure(window != nil)
 
-    window_size_x := i32(Start_Window_Size_X)
-    window_size_y := i32(Start_Window_Size_Y)
+    display_scale: f32 = sdl.GetWindowDisplayScale(window)
+
+    window_size_x := i32(Start_Window_Size_X * display_scale)
+    window_size_y := i32(Start_Window_Size_Y * display_scale)
 
     ok := gpu.init()
     ensure(ok)
@@ -140,7 +150,7 @@ main :: proc()
 
         old_window_size_x := window_size_x
         old_window_size_y := window_size_y
-        sdl.GetWindowSize(window, &window_size_x, &window_size_y)
+        sdl.GetWindowSizeInPixels(window, &window_size_x, &window_size_y)
         if .MINIMIZED in sdl.GetWindowFlags(window) || window_size_x <= 0 || window_size_y <= 0
         {
             sdl.Delay(16)

--- a/examples/6_compute_shaders/main.odin
+++ b/examples/6_compute_shaders/main.odin
@@ -5,6 +5,7 @@ import log "core:log"
 import "core:math"
 import "core:math/linalg"
 import "core:fmt"
+import "../shared"
 
 import "../../gpu"
 
@@ -22,16 +23,7 @@ main :: proc()
 {
     fmt.println("CREDITS: Shader \"Clearly a bug\" by Glow on https://www.shadertoy.com/view/33cGDj")
 
-    ok_i := sdl.Init({ .VIDEO })
-    assert(ok_i)
-
-    when ODIN_OS == .Darwin 
-    {
-        if (!sdl.Vulkan_LoadLibrary("libvulkan.1.dylib"))
-        {
-            panic("Unable to load vulkan library!")
-        }
-    }
+    shared.sdl_init()
 
     console_logger := log.create_console_logger()
     defer log.destroy_console_logger(console_logger)

--- a/examples/7_deferred_async_load/main.odin
+++ b/examples/7_deferred_async_load/main.odin
@@ -79,7 +79,7 @@ main :: proc() {
     shared.CAM_POS = {-7.581631, 1.1906259, 0.25928685}
 	shared.CAM_ANGLE = {1.570796, 0.3665192}
 
-	shared.sdl_init(works_with_moltenvk=false)
+	shared.sdl_init(moltenvk_working_status = .Does_Not_Work)
 
 	console_logger := log.create_console_logger()
 	defer log.destroy_console_logger(console_logger)

--- a/examples/7_deferred_async_load/main.odin
+++ b/examples/7_deferred_async_load/main.odin
@@ -95,16 +95,7 @@ main :: proc() {
     shared.CAM_POS = {-7.581631, 1.1906259, 0.25928685}
 	shared.CAM_ANGLE = {1.570796, 0.3665192}
 
-	ok_i := sdl.Init({.VIDEO})
-	assert(ok_i)
-
-	when ODIN_OS == .Darwin 
-	{
-        if (!sdl.Vulkan_LoadLibrary("libvulkan.1.dylib"))
-        {
-            panic("Unable to load vulkan library!")
-        }
-    }
+	shared.sdl_init()
 
 	console_logger := log.create_console_logger()
 	defer log.destroy_console_logger(console_logger)
@@ -692,7 +683,7 @@ load_scene_textures_from_gltf :: proc(
 	desc_pool: ^gpu.Descriptor_Pool
 ) {
 	upload_arena := gpu.arena_init()
-	// defer gpu.arena_destroy(&upload_arena)
+	defer gpu.arena_destroy(&upload_arena)
 
 	for info, i in texture_infos {
 		if cancel_loading_textures {
@@ -780,10 +771,10 @@ load_scene_textures_from_gltf :: proc(
 		}
 	}
 
-	if sync.guard(&deletion_mutex)
-	{
-	    append(&arena_deletion_stack, upload_arena)
-	}
+	// if sync.guard(&deletion_mutex)
+	// {
+	//     append(&arena_deletion_stack, upload_arena)
+	// }
 }
 
 upload_texture :: proc(

--- a/examples/7_deferred_async_load/main.odin
+++ b/examples/7_deferred_async_load/main.odin
@@ -7,7 +7,6 @@
 
 package main
 
-import "core:time"
 import "../../gpu"
 import intr "base:intrinsics"
 import "base:runtime"
@@ -76,26 +75,11 @@ image_uploaded: map[int]^sync.One_Shot_Event
 upload_sem: gpu.Semaphore
 upload_sem_val: u64
 
-
-// NOTE:
-// To ensure memory used for staging buffers during 'upload_texture' and 'upload_bc3_texture'
-// remains valid until all related GPU work is done, we use a "stack" to hold onto a list
-// of arenas that are prime for deletion.
-// 
-// The arenas in this "stack" get deleted at the next available frame. Delaying deletion
-// until previous GPU work for presenting to the semaphore is done.
-// 
-// By doing this, we give the GPU just enough time to finish the transfer queue work 
-// and it prevents us from crashing due to invalid memory access on stricter drivers 
-// (i.e., MoltenVK on macOS).
-deletion_mutex: sync.Mutex
-arena_deletion_stack: [dynamic]gpu.Arena
-
 main :: proc() {
     shared.CAM_POS = {-7.581631, 1.1906259, 0.25928685}
 	shared.CAM_ANGLE = {1.570796, 0.3665192}
 
-	shared.sdl_init()
+	shared.sdl_init(works_with_moltenvk=false)
 
 	console_logger := log.create_console_logger()
 	defer log.destroy_console_logger(console_logger)
@@ -309,14 +293,6 @@ main :: proc() {
 
 		if next_frame > Frames_In_Flight {
 			gpu.semaphore_wait(frame_sem, next_frame - Frames_In_Flight)
-			if sync.guard(&deletion_mutex)
-			{
-			    for &arena in arena_deletion_stack
-				{
-				    gpu.arena_destroy(&arena)
-				}
-				clear(&arena_deletion_stack)
-			}
 		}
 		if old_window_size_x != window_size_x || old_window_size_y != window_size_y {
 			gpu.queue_wait_idle(.Main)
@@ -683,7 +659,7 @@ load_scene_textures_from_gltf :: proc(
 	desc_pool: ^gpu.Descriptor_Pool
 ) {
 	upload_arena := gpu.arena_init()
-	// defer gpu.arena_destroy(&upload_arena)
+	defer gpu.arena_destroy(&upload_arena)
 
 	for info, i in texture_infos {
 		if cancel_loading_textures {
@@ -769,11 +745,6 @@ load_scene_textures_from_gltf :: proc(
 		case .Normal:
 			scene.meshes[info.mesh_id].normal_map = texture.texture_idx
 		}
-	}
-
-	if sync.guard(&deletion_mutex)
-	{
-	    append(&arena_deletion_stack, upload_arena)
 	}
 }
 

--- a/examples/7_deferred_async_load/main.odin
+++ b/examples/7_deferred_async_load/main.odin
@@ -683,7 +683,7 @@ load_scene_textures_from_gltf :: proc(
 	desc_pool: ^gpu.Descriptor_Pool
 ) {
 	upload_arena := gpu.arena_init()
-	defer gpu.arena_destroy(&upload_arena)
+	// defer gpu.arena_destroy(&upload_arena)
 
 	for info, i in texture_infos {
 		if cancel_loading_textures {
@@ -771,10 +771,10 @@ load_scene_textures_from_gltf :: proc(
 		}
 	}
 
-	// if sync.guard(&deletion_mutex)
-	// {
-	//     append(&arena_deletion_stack, upload_arena)
-	// }
+	if sync.guard(&deletion_mutex)
+	{
+	    append(&arena_deletion_stack, upload_arena)
+	}
 }
 
 upload_texture :: proc(

--- a/examples/7_deferred_async_load/main.odin
+++ b/examples/7_deferred_async_load/main.odin
@@ -7,6 +7,7 @@
 
 package main
 
+import "core:time"
 import "../../gpu"
 import intr "base:intrinsics"
 import "base:runtime"
@@ -75,12 +76,35 @@ image_uploaded: map[int]^sync.One_Shot_Event
 upload_sem: gpu.Semaphore
 upload_sem_val: u64
 
+
+// NOTE:
+// To ensure memory used for staging buffers during 'upload_texture' and 'upload_bc3_texture'
+// remains valid until all related GPU work is done, we use a "stack" to hold onto a list
+// of arenas that are prime for deletion.
+// 
+// The arenas in this "stack" get deleted at the next available frame. Delaying deletion
+// until previous GPU work for presenting to the semaphore is done.
+// 
+// By doing this, we give the GPU just enough time to finish the transfer queue work 
+// and it prevents us from crashing due to invalid memory access on stricter drivers 
+// (i.e., MoltenVK on macOS).
+deletion_mutex: sync.Mutex
+arena_deletion_stack: [dynamic]gpu.Arena
+
 main :: proc() {
     shared.CAM_POS = {-7.581631, 1.1906259, 0.25928685}
 	shared.CAM_ANGLE = {1.570796, 0.3665192}
 
 	ok_i := sdl.Init({.VIDEO})
 	assert(ok_i)
+
+	when ODIN_OS == .Darwin 
+	{
+        if (!sdl.Vulkan_LoadLibrary("libvulkan.1.dylib"))
+        {
+            panic("Unable to load vulkan library!")
+        }
+    }
 
 	console_logger := log.create_console_logger()
 	defer log.destroy_console_logger(console_logger)
@@ -102,8 +126,10 @@ main :: proc() {
 	)
 	ensure(window != nil)
 
-	window_size_x := i32(Start_Window_Size_X)
-	window_size_y := i32(Start_Window_Size_Y)
+	display_scale: f32 = sdl.GetWindowDisplayScale(window)
+
+	window_size_x := i32(Start_Window_Size_X * display_scale)
+	window_size_y := i32(Start_Window_Size_Y * display_scale)
 
 	ok := gpu.init()
 	ensure(ok)
@@ -284,7 +310,7 @@ main :: proc() {
 
 		old_window_size_x := window_size_x
 		old_window_size_y := window_size_y
-		sdl.GetWindowSize(window, &window_size_x, &window_size_y)
+		sdl.GetWindowSizeInPixels(window, &window_size_x, &window_size_y)
 		if .MINIMIZED in sdl.GetWindowFlags(window) || window_size_x <= 0 || window_size_y <= 0 {
 			sdl.Delay(16)
 			continue
@@ -292,6 +318,14 @@ main :: proc() {
 
 		if next_frame > Frames_In_Flight {
 			gpu.semaphore_wait(frame_sem, next_frame - Frames_In_Flight)
+			if sync.guard(&deletion_mutex)
+			{
+			    for &arena in arena_deletion_stack
+				{
+				    gpu.arena_destroy(&arena)
+				}
+				clear(&arena_deletion_stack)
+			}
 		}
 		if old_window_size_x != window_size_x || old_window_size_y != window_size_y {
 			gpu.queue_wait_idle(.Main)
@@ -655,10 +689,10 @@ load_scene_textures_from_gltf :: proc(
 	texture_infos: []shared.Gltf_Texture_Info,
 	data: ^gltf2.Data,
 	scene: ^shared.Scene,
-	desc_pool: ^gpu.Descriptor_Pool,
+	desc_pool: ^gpu.Descriptor_Pool
 ) {
 	upload_arena := gpu.arena_init()
-	defer gpu.arena_destroy(&upload_arena)
+	// defer gpu.arena_destroy(&upload_arena)
 
 	for info, i in texture_infos {
 		if cancel_loading_textures {
@@ -744,6 +778,11 @@ load_scene_textures_from_gltf :: proc(
 		case .Normal:
 			scene.meshes[info.mesh_id].normal_map = texture.texture_idx
 		}
+	}
+
+	if sync.guard(&deletion_mutex)
+	{
+	    append(&arena_deletion_stack, upload_arena)
 	}
 }
 

--- a/examples/8_raytracing/main.odin
+++ b/examples/8_raytracing/main.odin
@@ -29,7 +29,10 @@ main :: proc()
 
     fmt.println("Right-click + WASD for first-person controls.")
 
-    shared.sdl_init(works_with_moltenvk=false)
+    shared.sdl_init(
+        moltenvk_working_status = .Does_Not_Work, 
+        kosmickrisp_working_status = .Does_Not_Work
+    )
 
     console_logger := log.create_console_logger()
     defer log.destroy_console_logger(console_logger)

--- a/examples/8_raytracing/main.odin
+++ b/examples/8_raytracing/main.odin
@@ -29,8 +29,7 @@ main :: proc()
 
     fmt.println("Right-click + WASD for first-person controls.")
 
-    ok_i := sdl.Init({ .VIDEO })
-    assert(ok_i)
+    shared.sdl_init(works_with_moltenvk=false)
 
     console_logger := log.create_console_logger()
     defer log.destroy_console_logger(console_logger)

--- a/examples/shared/shared.odin
+++ b/examples/shared/shared.odin
@@ -22,7 +22,7 @@ MACOS_SDL_INIT_VULKAN_ERR_MSG :: `
 Failed to load the vulkan library on macOS!
 
 NOTE:
-If you are having trouble running this on macOS, you might not have the 'VULKAN_SDK' environment variable populated. Make sure to "source" the "setup-env.sh" script present within the 'VulkanSDK' folder before running the app. 
+If you are having trouble running this on macOS, you might not have the 'VULKAN_SDK' environment variable populated. Make sure to "source" the "setup-env.sh" script present within the 'VulkanSDK' folder before running the app.
 
 Like this:
 > source ~/VulkanSDK/1.x.xxx.x/setup-env.sh
@@ -39,22 +39,22 @@ sdl_init :: proc(moltenvk_working_status := Working_Status.Works, kosmickrisp_wo
 {
     ok_i := sdl.Init({.VIDEO})
 	assert(ok_i)
-        
+
     when ODIN_OS == .Darwin
     {
         // NOTE:
         // We make the assumption that if `VK_DRIVER_FILES` does *not* contain `libkosmickrisp`,
-        // it is running MoltenVK. This is because, for now, MoltenVK is the default on macOS. 
+        // it is running MoltenVK. This is because, for now, MoltenVK is the default on macOS.
         // Until that changes, we will continue to make this assumption in the example setup
         // code.
         driver_used := os.get_env_alloc("VK_DRIVER_FILES", context.temp_allocator)
 
         using_moltenvk := !(strings.contains(driver_used, "libkosmickrisp"))
 
-        if using_moltenvk 
+        if using_moltenvk
         {
             ensure(moltenvk_working_status != .Does_Not_Work, "This example unfortunately does not work on MoltenVK!")
-            if moltenvk_working_status == .Partially_Works 
+            if moltenvk_working_status == .Partially_Works
             {
                 fmt.printfln("[WARNING] - For this example, MoltenVK only partially works.")
             }
@@ -62,13 +62,13 @@ sdl_init :: proc(moltenvk_working_status := Working_Status.Works, kosmickrisp_wo
         else
         {
             ensure(kosmickrisp_working_status != .Does_Not_Work, "This example unfortunately does not work on KosmicKrisp!")
-            if kosmickrisp_working_status == .Partially_Works 
+            if kosmickrisp_working_status == .Partially_Works
             {
                 fmt.printfln("[WARNING] - For this example, KosmicKrisp only partially works.")
             }
         }
-        
-        if (!sdl.Vulkan_LoadLibrary("libvulkan.1.dylib"))
+
+        if !sdl.Vulkan_LoadLibrary("libvulkan.1.dylib")
         {
             panic(MACOS_SDL_INIT_VULKAN_ERR_MSG)
         }

--- a/examples/shared/shared.odin
+++ b/examples/shared/shared.odin
@@ -10,11 +10,26 @@ import "core:mem"
 import "core:slice"
 import "gltf2"
 import "core:image"
+import "core:strings"
 import "core:image/jpeg"
 import "core:image/png"
 import intr "base:intrinsics"
 
 import sdl "vendor:sdl3"
+
+sdl_init :: proc()
+{
+    ok_i := sdl.Init({.VIDEO})
+	assert(ok_i)
+        
+    when ODIN_OS == .Darwin
+    {
+        if (!sdl.Vulkan_LoadLibrary("libvulkan.1.dylib"))
+        {
+            panic("Unable to load vulkan library on macos!")
+        }
+    }
+}
 
 Texture_Type :: enum {
 	Base_Color,

--- a/examples/shared/shared.odin
+++ b/examples/shared/shared.odin
@@ -14,8 +14,19 @@ import "core:strings"
 import "core:image/jpeg"
 import "core:image/png"
 import intr "base:intrinsics"
+import "core:os"
 
 import sdl "vendor:sdl3"
+
+MACOS_SDL_INIT_VULKAN_ERR_MSG :: `
+Failed to load the vulkan library on macOS!
+
+NOTE:
+If you are having trouble running this on macOS, you might not have the 'VULKAN_SDK' environment variable populated. Make sure to "source" the "setup-env.sh" script present within the 'VulkanSDK' folder before running the app. 
+
+Like this:
+> source ~/VulkanSDK/1.x.xxx.x/setup-env.sh
+`
 
 sdl_init :: proc()
 {
@@ -26,7 +37,7 @@ sdl_init :: proc()
     {
         if (!sdl.Vulkan_LoadLibrary("libvulkan.1.dylib"))
         {
-            panic("Unable to load vulkan library on macos!")
+            panic(MACOS_SDL_INIT_VULKAN_ERR_MSG)
         }
     }
 }

--- a/examples/shared/shared.odin
+++ b/examples/shared/shared.odin
@@ -28,13 +28,26 @@ Like this:
 > source ~/VulkanSDK/1.x.xxx.x/setup-env.sh
 `
 
-sdl_init :: proc()
+sdl_init :: proc(works_with_moltenvk := true)
 {
     ok_i := sdl.Init({.VIDEO})
 	assert(ok_i)
         
     when ODIN_OS == .Darwin
     {
+        // NOTE:
+        // We make the assumption that if `VK_DRIVER_FILES` does *not* contain `libkosmickrisp`,
+        // it is running MoltenVK. This is because, for now, MoltenVK is the default on macOS. 
+        // Until that changes, we will continue to make this assumption in the example setup
+        // code.
+        driver_used := os.get_env_alloc("VK_DRIVER_FILES", context.temp_allocator)
+
+        using_moltenvk := !(strings.contains(driver_used, "libkosmickrisp"))
+
+        if using_moltenvk {
+            ensure(works_with_moltenvk, "This example unfortunately does not work on MoltenVK!")
+        }
+        
         if (!sdl.Vulkan_LoadLibrary("libvulkan.1.dylib"))
         {
             panic(MACOS_SDL_INIT_VULKAN_ERR_MSG)

--- a/examples/shared/shared.odin
+++ b/examples/shared/shared.odin
@@ -28,7 +28,14 @@ Like this:
 > source ~/VulkanSDK/1.x.xxx.x/setup-env.sh
 `
 
-sdl_init :: proc(works_with_moltenvk := true)
+Working_Status :: enum
+{
+    Works,
+    Partially_Works,
+    Does_Not_Work,
+}
+
+sdl_init :: proc(moltenvk_working_status := Working_Status.Works, kosmickrisp_working_status := Working_Status.Works)
 {
     ok_i := sdl.Init({.VIDEO})
 	assert(ok_i)
@@ -44,8 +51,21 @@ sdl_init :: proc(works_with_moltenvk := true)
 
         using_moltenvk := !(strings.contains(driver_used, "libkosmickrisp"))
 
-        if using_moltenvk {
-            ensure(works_with_moltenvk, "This example unfortunately does not work on MoltenVK!")
+        if using_moltenvk 
+        {
+            ensure(moltenvk_working_status != .Does_Not_Work, "This example unfortunately does not work on MoltenVK!")
+            if moltenvk_working_status == .Partially_Works 
+            {
+                fmt.printfln("[WARNING] - For this example, MoltenVK only partially works.")
+            }
+        }
+        else
+        {
+            ensure(kosmickrisp_working_status != .Does_Not_Work, "This example unfortunately does not work on KosmicKrisp!")
+            if kosmickrisp_working_status == .Partially_Works 
+            {
+                fmt.printfln("[WARNING] - For this example, KosmicKrisp only partially works.")
+            }
         }
         
         if (!sdl.Vulkan_LoadLibrary("libvulkan.1.dylib"))

--- a/gpu/gpu.odin
+++ b/gpu/gpu.odin
@@ -29,7 +29,7 @@ Texture_Descriptor :: distinct Big_Handle
 Sampler_Descriptor :: distinct Handle
 
 // Enums
-Feature :: enum { Raytracing = 0 }
+Feature :: enum { Raytracing = 0, Draw_Indirect_Multi }
 Features :: bit_set[Feature; u32]
 Memory :: enum { Default = 0, GPU, Readback }
 Queue :: enum { Main = 0, Compute, Transfer }

--- a/gpu/impl_vk.odin
+++ b/gpu/impl_vk.odin
@@ -360,9 +360,12 @@ _init :: proc(validation := true, loc := #caller_location) -> bool
         vk.KHR_RAY_QUERY_EXTENSION_NAME,
     }
 
+    draw_indirect_multi_extension := cstring(vk.KHR_DRAW_INDIRECT_COUNT_EXTENSION_NAME) 
+
     // Query physical device feature availability
     {
         supports_raytracing := true
+        supports_draw_indirect_multi := false
 
         count: u32
         vk.EnumerateDeviceExtensionProperties(ctx.phys_device, nil, &count, nil)
@@ -386,6 +389,15 @@ _init :: proc(validation := true, loc := #caller_location) -> bool
             }
         }
 
+        for &supported_ext in extensions
+        {
+            if cstring(&supported_ext.extensionName[0]) == draw_indirect_multi_extension
+            {
+                supports_draw_indirect_multi = true
+                break
+            }
+        }
+
         ray_query_features := vk.PhysicalDeviceRayQueryFeaturesKHR {
             sType = .PHYSICAL_DEVICE_RAY_QUERY_FEATURES_KHR
         }
@@ -402,6 +414,7 @@ _init :: proc(validation := true, loc := #caller_location) -> bool
         supports_raytracing = supports_raytracing && accel_features.accelerationStructure && ray_query_features.rayQuery
 
         if supports_raytracing do ctx.features += { .Raytracing }
+        if supports_draw_indirect_multi do ctx.features += { .Draw_Indirect_Multi }
     }
 
     // Get physical device properties
@@ -458,12 +471,12 @@ _init :: proc(validation := true, loc := #caller_location) -> bool
 
         required_extensions := make([dynamic]cstring, allocator = scratch)
         append(&required_extensions, vk.KHR_SWAPCHAIN_EXTENSION_NAME)
+        append(&required_extensions, vk.EXT_SHADER_OBJECT_EXTENSION_NAME)
         for req_ext in EXTRA_DEVICE_EXTENSIONS {
             append(&required_extensions, req_ext)
         }
 
         optional_extensions := make([dynamic]cstring, allocator = scratch)
-        append(&optional_extensions, vk.EXT_SHADER_OBJECT_EXTENSION_NAME)
         append(&optional_extensions, vk.KHR_PORTABILITY_SUBSET_EXTENSION_NAME)
         for opt_ext in EXTRA_OPT_DEVICE_EXTENSIONS {
             append(&optional_extensions, opt_ext)
@@ -480,23 +493,18 @@ _init :: proc(validation := true, loc := #caller_location) -> bool
             log_unsupported_extensions(unsupported_extensions[:], loc)
             return false
         }
-
-        supports_draw_index_count := b32(false)
-        if supports_device_extension(vk.KHR_DRAW_INDIRECT_COUNT_EXTENSION_NAME)
-        {
-            supports_draw_index_count = true
-            append(&required_extensions, vk.KHR_DRAW_INDIRECT_COUNT_EXTENSION_NAME)
-
-            // Maybe this is a bad place organization-wise to place this?
-            ctx.features += { .Draw_Indirect_Multi }
-        }
-
+        
         // Add optional extensions
         if .Raytracing in ctx.features
         {
             append(&required_extensions, vk.KHR_DEFERRED_HOST_OPERATIONS_EXTENSION_NAME)
             append(&required_extensions, vk.KHR_RAY_QUERY_EXTENSION_NAME)
             append(&required_extensions, vk.KHR_ACCELERATION_STRUCTURE_EXTENSION_NAME)
+        }
+
+        if .Draw_Indirect_Multi in ctx.features
+        {
+            append(&required_extensions, vk.KHR_DRAW_INDIRECT_COUNT_EXTENSION_NAME)
         }
 
         for opt in optional_extensions {
@@ -517,7 +525,7 @@ _init :: proc(validation := true, loc := #caller_location) -> bool
             descriptorBindingPartiallyBound = true,
             timelineSemaphore = true,
             bufferDeviceAddress = true,
-            drawIndirectCount = supports_draw_index_count,
+            drawIndirectCount = b32(.Draw_Indirect_Multi in ctx.features),
             scalarBlockLayout = true,
             shaderInt8 = true,
         }

--- a/gpu/impl_vk.odin
+++ b/gpu/impl_vk.odin
@@ -254,6 +254,8 @@ _init :: proc(validation := true, loc := #caller_location) -> bool
         append(&optional_extensions, "VK_KHR_win32_surface")
         append(&optional_extensions, "VK_KHR_wayland_surface")
         append(&optional_extensions, "VK_KHR_xlib_surface")
+        append(&optional_extensions, vk.EXT_METAL_SURFACE_EXTENSION_NAME)
+        append(&optional_extensions, vk.KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME)
 
         // Check that required_extensions are supported
         for req in required_extensions {
@@ -300,6 +302,7 @@ _init :: proc(validation := true, loc := #caller_location) -> bool
                 sType = .APPLICATION_INFO,
                 apiVersion = vk.API_VERSION_1_3,
             },
+            flags = { .ENUMERATE_PORTABILITY_KHR },
             enabledLayerCount = u32(len(required_layers)),
             ppEnabledLayerNames = raw_data(required_layers),
             enabledExtensionCount = u32(len(required_extensions)),
@@ -455,13 +458,13 @@ _init :: proc(validation := true, loc := #caller_location) -> bool
 
         required_extensions := make([dynamic]cstring, allocator = scratch)
         append(&required_extensions, vk.KHR_SWAPCHAIN_EXTENSION_NAME)
-        append(&required_extensions, vk.EXT_SHADER_OBJECT_EXTENSION_NAME)
-        append(&required_extensions, vk.KHR_DRAW_INDIRECT_COUNT_EXTENSION_NAME)
         for req_ext in EXTRA_DEVICE_EXTENSIONS {
             append(&required_extensions, req_ext)
         }
 
         optional_extensions := make([dynamic]cstring, allocator = scratch)
+        append(&optional_extensions, vk.EXT_SHADER_OBJECT_EXTENSION_NAME)
+        append(&optional_extensions, vk.KHR_PORTABILITY_SUBSET_EXTENSION_NAME)
         for opt_ext in EXTRA_OPT_DEVICE_EXTENSIONS {
             append(&optional_extensions, opt_ext)
         }
@@ -476,6 +479,16 @@ _init :: proc(validation := true, loc := #caller_location) -> bool
         if len(unsupported_extensions) > 0 {
             log_unsupported_extensions(unsupported_extensions[:], loc)
             return false
+        }
+
+        supports_draw_index_count := b32(false)
+        if supports_device_extension(vk.KHR_DRAW_INDIRECT_COUNT_EXTENSION_NAME)
+        {
+            supports_draw_index_count = true
+            append(&required_extensions, vk.KHR_DRAW_INDIRECT_COUNT_EXTENSION_NAME)
+
+            // Maybe this is a bad place organization-wise to place this?
+            ctx.features += { .Draw_Indirect_Multi }
         }
 
         // Add optional extensions
@@ -504,7 +517,7 @@ _init :: proc(validation := true, loc := #caller_location) -> bool
             descriptorBindingPartiallyBound = true,
             timelineSemaphore = true,
             bufferDeviceAddress = true,
-            drawIndirectCount = true,
+            drawIndirectCount = supports_draw_index_count,
             scalarBlockLayout = true,
             shaderInt8 = true,
         }
@@ -527,7 +540,9 @@ _init :: proc(validation := true, loc := #caller_location) -> bool
         next = &vk.PhysicalDeviceDepthClipEnableFeaturesEXT {
             sType = .PHYSICAL_DEVICE_DEPTH_CLIP_ENABLE_FEATURES_EXT,
             pNext = next,
-            depthClipEnable = true,
+            // NOTE(MP): On darwin (macOS, iOS, etc.), this extension doesn't
+            // exist, however, thankfully, depth clip is already the default there.
+            depthClipEnable = ODIN_OS != .Darwin,
         }
         next = &vk.PhysicalDeviceFeatures2 {
             sType = .PHYSICAL_DEVICE_FEATURES_2,
@@ -759,6 +774,8 @@ _init :: proc(validation := true, loc := #caller_location) -> bool
             vk_dll_path = "libvulkan.so"
         } else when ODIN_OS == .Linux {
             vk_dll_path = "libvulkan.so.1"
+        } else when ODIN_OS == .Darwin {
+            vk_dll_path = "libvulkan.1.dylib"
         } else do #panic("OS not supported!")
 
         @(static) vk_dll: dynlib.Library
@@ -2534,8 +2551,10 @@ _cmd_set_depth_state :: proc(cmd_buf: Command_Buffer, state: Depth_State, loc :=
     vk.CmdSetDepthTestEnable(vk_cmd_buf, .Read in state.mode)
     vk.CmdSetDepthWriteEnable(vk_cmd_buf, .Write in state.mode)
     vk.CmdSetDepthBiasEnable(vk_cmd_buf, false)
-    vk.CmdSetDepthClipEnableEXT(vk_cmd_buf, true)
     vk.CmdSetStencilTestEnable(vk_cmd_buf, false)
+    when ODIN_OS != .Darwin {
+        vk.CmdSetDepthClipEnableEXT(vk_cmd_buf, true)
+    }
 }
 
 _cmd_set_raster_state :: proc(cmd_buf: Command_Buffer, state: Raster_State, loc := #caller_location)
@@ -2786,7 +2805,9 @@ _cmd_begin_render_pass :: proc(cmd_buf: Command_Buffer, desc: Render_Pass_Desc, 
     vk.CmdSetDepthTestEnable(vk_cmd_buf, false)
     vk.CmdSetDepthWriteEnable(vk_cmd_buf, false)
     vk.CmdSetDepthBiasEnable(vk_cmd_buf, false)
-    vk.CmdSetDepthClipEnableEXT(vk_cmd_buf, true)
+    when ODIN_OS != .Darwin {
+        vk.CmdSetDepthClipEnableEXT(vk_cmd_buf, true)
+    }
 
     // Viewport
     viewport := vk.Viewport {
@@ -2936,6 +2957,7 @@ _cmd_draw_indexed_indirect_multi_raw :: proc(cmd_buf: Command_Buffer, vertex_dat
         ok &= check_ptr_allow_nil(indices, "indices", loc)
         ok &= check_ptr(indirect_arguments, "indirect_arguments", loc)
         ok &= check_ptr(draw_count, "draw_count", loc)
+        ok &= supports_indirect_multi_draw(loc)
         if !ok do return
     }
 
@@ -3902,4 +3924,16 @@ vk_set_debug_name :: proc(name: string, handle: u64, type: vk.ObjectType)
         objectHandle = handle,
         pObjectName = name_cstr,
     })
+}
+
+@(private="file")
+supports_indirect_multi_draw :: proc(loc: runtime.Source_Code_Location) -> bool
+{
+    if .Draw_Indirect_Multi not_in ctx.features
+    {
+        log.errorf("'cmd_draw_indexed_indirect_multi*' is not supported on this device.", location = loc)
+        return false
+    }
+
+    return true
 }

--- a/gpu/vma/vma.odin
+++ b/gpu/vma/vma.odin
@@ -5,7 +5,7 @@ when ODIN_OS == .Linux {
 	foreign import stdcpp "system:stdc++"
 }
 when ODIN_OS == .Darwin {
-	@(require, extra_linker_flags = "-lstdc++")
+	@(require)
 	foreign import stdcpp "system:c++"
 }
 

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@
 
 It isn't controversial to say this: graphics APIs are a mess. "Modern" graphics APIs – which are a decade old at this point – all present numerous concepts that are completely useless on today's hardware. They are extremely bloated, often adding new extensions to cover for past missteps in the design. It can all be massively simplified.
 
-**no_gfx**'s goal is to implement an ideal "API of the future" on top of existing APIs (Vulkan), greatly simplifying graphics programming without sacrificing modern features like indirect rendering and raytracing. It initially started as a 1:1 recreation of the theoretical API outlined in Sebastian Aaltonen's ["No Graphics API"](https://www.sebastianaaltonen.com/blog/no-graphics-api) blog post; there are now a few divergences – partly due to the limitations of current APIs – but the overall design and core philosophy is still the same.
+**no_gfx**'s goal is to implement an ideal "API of the future" on top of Vulkan, greatly simplifying graphics programming without sacrificing modern features like indirect rendering and raytracing. It initially started as a 1:1 recreation of the theoretical API outlined in Sebastian Aaltonen's ["No Graphics API"](https://www.sebastianaaltonen.com/blog/no-graphics-api) blog post; there are now a few divergences – partly due to the limitations of current APIs – but the overall design and core philosophy is still the same.
 
 ## API Usage
 
@@ -110,6 +110,7 @@ Like most things in life, this is not without its tradeoffs:
 
 1. It assumes relatively recent hardware. It requires Vulkan 1.3 with the following extensions: VK_EXT_shader_object, VK_EXT_descriptor_buffer, VK_KHR_draw_indirect_count. It can use more extensions for optional features such as raytracing.
 2. Shader arguments are all passed via a single pointer. This is very flexible and easy to work with, but it can also prevent some prefetching/optimizations that drivers usually implement with standard bindings and vertex buffers. This will probably make shaders in general slightly slower. How much impact this will have, I can't say for sure right now. On the other hand, working with a nicer and better API can make optimization easier and quicker.
+3. It currently only targets Vulkan, so it's not fully cross-platform. Mac support is best-effort, through MoltenVK/KosmicKrisp only. Developing on Mac is probably doable, but if shipping to Mac is desired I'd consider the option of writing a separate Metal backend for your application.
 
 ## Shaders
 


### PR DESCRIPTION
# Main Code Changes

To do this, we had to make a relatively big change:
- The `VK_KHR_draw_indirect_count` extension can no longer be a required extension, instead it is now a "feature" (just like raytracing), which you can query to check if it's available for your device through `gpu.features_available()`. This is because MoltenVK simply does not support the extension. This change only affects the `gpu.cmd_draw_indexed_indirect_multi` procedure.
- However, on MoltenVK, `gpu.cmd_draw_indexed_indirect` will continue to work with the only caveat that in the shaders, `DrawIndex` (or as it's referred to in slang `SV_DrawIndex`) is currently not supported (but that will change!). 

To add, shader objects are no longer listed as a required extension. Instead, we now have it set as optional, and if it isn't found, it'll fallback onto Khronos' software-backed implementation of shader objects. This allows devices that don't explicitly support the extension to run the code just fine. This is also what allows us to run the api on macOS without any changes despite not having the extension.

For darwin platforms (macOS, iOS, etc.), we disable the `depthClipEnable` feature during logical device creation, since it is not supported by MoltenVK.

# Example Code Changes

In addition, most of the examples received slight code changes to make them work on macOS, with none of those changes effecting how it works on other platforms, such as linux (windows is untested, as I do not have a windows device at the moment). These are the examples that work on macOS:
- `1_triangle`
- `2_textures`
- `3_3D`
- `4_textures_advanced`
- `6_compute_shaders`
- `7_deferred_async_load`

## Changes Present Across All Examples

1. The start of the main procedure now features a `sdl.Vulkan_LoadLibrary` call to load `libvulkan.1.dylib` on darwin platforms. This is to tell SDL where to load vulkan from and to initialize SDL's relevant vulkan procedures. This call is important as it prevents the call to `sdl.Vulkan_CreateSurface` in `gpu.init_swapchain_from_sdl` from crashing (segfaulting) on us in macOS.

2. The reported window size has been changed and now makes use of the `sdl.GetWindowSizeInPixels` procedure rather than `sdl.GetWindowSize`. This allows us to get the size in terms of pixel density rather than desktop space, which in the case of MoltenVK, is necessary to render properly. Otherwise, this'll lead to the content rendered being a quarter of the window's size.

## `7_deferred_async_load`

Example `7_deferred_async_load` had to be modified a bit more than the others, simply because I was crashing while loading the textures. It turns out that the memory associated to the staging buffers found in `upload_texture` and `upload_bc3_texture` were not living long enough and thus would crash the program as they became invalid. The arena they were being allocated from was being destroyed at the end of the `load_scene_textures_from_gltf` procedure.

My solution was to prolong the arena's lifetime slightly by delaying their deletion until the next available frame. This gave the queue enough time to complete it's work, and since that change, I haven't experienced a crash with the async texture loading on my device. 

Curiously, the synchronous loading always worked despite going to the same procedure. It might've been due to the difference in work allocated to the queue at the time, causing the timing to play a massive role in whether it'd actually finish successfully. But at the moment, I can't be too sure.

## `5_indirect_triangles`

Example `5_indirect_triangles` compiles and runs, but since the aforementioned `DrawIndex` is not supported in the `spirv -> metal shader` pipeline, it cannot index any of the indirect buffer values. However, there is good news! As of just last month, there was a pull request that [implemented exactly that feature](https://github.com/KhronosGroup/MoltenVK/pull/2742), it'll just require us to wait until the next release (which may take a few months to see this become generally available in the VulkanSDK).

Unfortunately, `5_indirect_triangles` will only be partially whole on macOS, as we still won't be able to run the code path that makes use of `gpu.cmd_draw_indexed_indirect_multi`. But that should generally be fine. As long as it's possible to invoke a code-path similar to it in the shader, we could possibly build a software-backed implementation to do synchronization between the gpu and cpu values, at the cost of some performance.